### PR TITLE
feat: add heading paragraph support (개요 1–7)

### DIFF
--- a/e2e/heading-styles.test.ts
+++ b/e2e/heading-styles.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import JSZip from 'jszip'
+import { cleanupFiles, parseOutput, runCli, validateFile } from './helpers'
+
+const tempFiles: string[] = []
+
+function tempPath(suffix: string, ext = '.hwpx'): string {
+  const p = join(tmpdir(), `e2e-heading-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`)
+  tempFiles.push(p)
+  return p
+}
+
+async function runCliNoDaemon(args: string[]) {
+  return runCli(args, { env: { HWPILOT_NO_DAEMON: '1' } })
+}
+
+afterEach(async () => {
+  await cleanupFiles(tempFiles)
+  tempFiles.length = 0
+})
+
+describe('Heading Styles — HWPX (created document)', () => {
+  describe('A. Basic Heading Roundtrip', () => {
+    it('creates HWPX, adds heading paragraph, and reads headingLevel', async () => {
+      const hwpxFile = tempPath('hwpx-basic', '.hwpx')
+
+      await runCliNoDaemon(['create', hwpxFile])
+      await runCliNoDaemon(['paragraph', 'add', hwpxFile, 's0', '제1장 서론', '--heading', '1', '--position', 'end'])
+
+      const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+      const doc = parseOutput(readResult) as any
+      const headingPara = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '제1장 서론')
+
+      expect(headingPara).toBeDefined()
+      expect(headingPara.headingLevel).toBe(1)
+      expect(headingPara.styleName).toBe('개요 1')
+    })
+  })
+
+  describe('B. Mixed Heading and Body', () => {
+    it('preserves mixed heading and body paragraph levels', async () => {
+      const hwpxFile = tempPath('hwpx-mixed', '.hwpx')
+
+      await runCliNoDaemon(['create', hwpxFile])
+      await runCliNoDaemon(['paragraph', 'add', hwpxFile, 's0', '제1장 제목', '--heading', '1', '--position', 'end'])
+      await runCliNoDaemon(['paragraph', 'add', hwpxFile, 's0', '본문 단락', '--position', 'end'])
+
+      const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+      const doc = parseOutput(readResult) as any
+      const headingPara = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '제1장 제목')
+      const bodyPara = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '본문 단락')
+
+      expect(headingPara.headingLevel).toBe(1)
+      expect(headingPara.styleName).toBe('개요 1')
+      expect(bodyPara.headingLevel).toBeUndefined()
+      expect(bodyPara.styleName).toBe('Normal')
+    })
+  })
+
+  describe('C. Style Name Option', () => {
+    it('applies heading style when --style name is used', async () => {
+      const hwpxFile = tempPath('hwpx-style-name', '.hwpx')
+
+      await runCliNoDaemon(['create', hwpxFile])
+      await runCliNoDaemon(['paragraph', 'add', hwpxFile, 's0', '스타일 기반 제목', '--style', '개요 2', '--position', 'end'])
+
+      const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+      const doc = parseOutput(readResult) as any
+      const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '스타일 기반 제목')
+
+      expect(para).toBeDefined()
+      expect(para.styleName).toBe('개요 2')
+      expect(para.headingLevel).toBe(2)
+    })
+  })
+
+  describe('D. Raw XML Cross-Validation', () => {
+    it('writes heading paragraph with correct hp:styleIDRef in section XML', async () => {
+      const hwpxFile = tempPath('hwpx-xml-style-ref', '.hwpx')
+      const marker = 'HWPX_HEADING_XML_2026'
+
+      await runCliNoDaemon(['create', hwpxFile])
+      await runCliNoDaemon(['paragraph', 'add', hwpxFile, 's0', marker, '--heading', '1', '--position', 'end'])
+
+      const data = await readFile(hwpxFile)
+      const zip = await JSZip.loadAsync(data)
+      const xml = await zip.file('Contents/section0.xml')?.async('string')
+
+      expect(xml).toBeDefined()
+      expect(xml).toContain(marker)
+      expect(xml).toContain('hp:styleIDRef="1"')
+      expect(xml).toContain('hp:paraPrIDRef="1"')
+    })
+  })
+})
+
+describe('Heading Styles — HWP and conversion', () => {
+  describe('A. HWP Roundtrip', () => {
+    it('creates HWP, adds heading paragraph, and reads headingLevel', async () => {
+      const hwpFile = tempPath('hwp-basic', '.hwp')
+
+      await runCliNoDaemon(['create', hwpFile])
+      await runCliNoDaemon(['paragraph', 'add', hwpFile, 's0', 'HWP 제목', '--heading', '1', '--position', 'end'])
+
+      const readResult = await runCliNoDaemon(['read', hwpFile, '--pretty'])
+      const doc = parseOutput(readResult) as any
+      const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === 'HWP 제목')
+
+      expect(para).toBeDefined()
+      expect(para.headingLevel).toBe(1)
+      expect(para.styleName).toBe('개요 1')
+      await validateFile(hwpFile)
+    })
+  })
+
+  describe('B. HWP -> HWPX conversion cross-validation', () => {
+    it('preserves heading style mapping after convert', async () => {
+      const hwpFile = tempPath('hwp-convert-source', '.hwp')
+      const hwpxFile = tempPath('hwp-convert-target', '.hwpx')
+
+      await runCliNoDaemon(['create', hwpFile])
+      await runCliNoDaemon(['paragraph', 'add', hwpFile, 's0', '변환 제목', '--heading', '2', '--position', 'end'])
+      await runCliNoDaemon(['convert', hwpFile, hwpxFile])
+
+      const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+      const doc = parseOutput(readResult) as any
+      const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '변환 제목')
+
+      expect(para).toBeDefined()
+      expect(para.styleName).toBe('개요 2')
+      expect(para.styleRef).toBe(2)
+      expect(para.paraShapeRef).toBe(2)
+    })
+  })
+})
+
+describe('Heading Styles — Error cases', () => {
+  it('rejects --heading 0', async () => {
+    const hwpxFile = tempPath('err-heading-zero', '.hwpx')
+    await runCliNoDaemon(['create', hwpxFile])
+
+    const result = await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpxFile,
+      's0',
+      '잘못된 heading 0',
+      '--heading',
+      '0',
+      '--position',
+      'end',
+    ])
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('Heading level must be between 1 and 7')
+  })
+
+  it('rejects --heading 8', async () => {
+    const hwpxFile = tempPath('err-heading-eight', '.hwpx')
+    await runCliNoDaemon(['create', hwpxFile])
+
+    const result = await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpxFile,
+      's0',
+      '잘못된 heading 8',
+      '--heading',
+      '8',
+      '--position',
+      'end',
+    ])
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('Heading level must be between 1 and 7')
+  })
+
+  it('rejects using --heading and --style together', async () => {
+    const hwpxFile = tempPath('err-heading-style-together', '.hwpx')
+    await runCliNoDaemon(['create', hwpxFile])
+
+    const result = await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpxFile,
+      's0',
+      '중복 옵션',
+      '--heading',
+      '1',
+      '--style',
+      '개요 1',
+      '--position',
+      'end',
+    ])
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('Cannot specify both --heading and --style')
+  })
+})

--- a/e2e/heading-styles.test.ts
+++ b/e2e/heading-styles.test.ts
@@ -65,7 +65,17 @@ describe('Heading Styles — HWPX (created document)', () => {
       const hwpxFile = tempPath('hwpx-style-name', '.hwpx')
 
       await runCliNoDaemon(['create', hwpxFile])
-      await runCliNoDaemon(['paragraph', 'add', hwpxFile, 's0', '스타일 기반 제목', '--style', '개요 2', '--position', 'end'])
+      await runCliNoDaemon([
+        'paragraph',
+        'add',
+        hwpxFile,
+        's0',
+        '스타일 기반 제목',
+        '--style',
+        '개요 2',
+        '--position',
+        'end',
+      ])
 
       const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
       const doc = parseOutput(readResult) as any

--- a/e2e/heading-styles.test.ts
+++ b/e2e/heading-styles.test.ts
@@ -210,3 +210,194 @@ describe('Heading Styles — Error cases', () => {
     expect(result.stderr).toContain('Cannot specify both --heading and --style')
   })
 })
+
+describe('Heading Styles — HWPX heading levels 3-7', () => {
+  for (const level of [3, 4, 5, 6, 7]) {
+    it(`creates HWPX with heading level ${level} and reads back correctly`, async () => {
+      const hwpxFile = tempPath(`hwpx-level-${level}`, '.hwpx')
+
+      await runCliNoDaemon(['create', hwpxFile])
+      await runCliNoDaemon([
+        'paragraph',
+        'add',
+        hwpxFile,
+        's0',
+        `레벨 ${level} 제목`,
+        '--heading',
+        String(level),
+        '--position',
+        'end',
+      ])
+
+      const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+      const doc = parseOutput(readResult) as any
+      const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === `레벨 ${level} 제목`)
+
+      expect(para).toBeDefined()
+      expect(para.headingLevel).toBe(level)
+      expect(para.styleName).toBe(`개요 ${level}`)
+    })
+  }
+})
+
+describe('Heading Styles — --style by numeric ID', () => {
+  it('resolves --style 3 to 개요 3 with headingLevel 3 on HWPX', async () => {
+    const hwpxFile = tempPath('hwpx-style-numeric', '.hwpx')
+
+    await runCliNoDaemon(['create', hwpxFile])
+    await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpxFile,
+      's0',
+      '숫자 스타일 테스트',
+      '--style',
+      '3',
+      '--position',
+      'end',
+    ])
+
+    const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+    const doc = parseOutput(readResult) as any
+    const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '숫자 스타일 테스트')
+
+    expect(para).toBeDefined()
+    expect(para.styleName).toBe('개요 3')
+    expect(para.headingLevel).toBe(3)
+  })
+})
+
+describe('Heading Styles — --style on HWP format', () => {
+  it('applies heading style by name on HWP and reads back headingLevel', async () => {
+    const hwpFile = tempPath('hwp-style-name', '.hwp')
+
+    await runCliNoDaemon(['create', hwpFile])
+    await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpFile,
+      's0',
+      'HWP 스타일 이름 테스트',
+      '--style',
+      '개요 2',
+      '--position',
+      'end',
+    ])
+
+    const readResult = await runCliNoDaemon(['read', hwpFile, '--pretty'])
+    const doc = parseOutput(readResult) as any
+    const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === 'HWP 스타일 이름 테스트')
+
+    expect(para).toBeDefined()
+    expect(para.headingLevel).toBe(2)
+    expect(para.styleName).toBe('개요 2')
+    await validateFile(hwpFile)
+  })
+})
+
+describe('Heading Styles — HWP mixed heading + body', () => {
+  it('heading paragraph has headingLevel, body paragraph does not', async () => {
+    const hwpFile = tempPath('hwp-mixed', '.hwp')
+
+    await runCliNoDaemon(['create', hwpFile])
+    await runCliNoDaemon(['paragraph', 'add', hwpFile, 's0', 'HWP 개요 제목', '--heading', '1', '--position', 'end'])
+    await runCliNoDaemon(['paragraph', 'add', hwpFile, 's0', 'HWP 본문 단락', '--position', 'end'])
+
+    const readResult = await runCliNoDaemon(['read', hwpFile, '--pretty'])
+    const doc = parseOutput(readResult) as any
+    const headingPara = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === 'HWP 개요 제목')
+    const bodyPara = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === 'HWP 본문 단락')
+
+    expect(headingPara).toBeDefined()
+    expect(headingPara.headingLevel).toBe(1)
+    expect(headingPara.styleName).toBe('개요 1')
+
+    expect(bodyPara).toBeDefined()
+    expect(bodyPara.headingLevel).toBeUndefined()
+    await validateFile(hwpFile)
+  })
+})
+
+describe('Heading Styles — HWP→HWPX conversion headingLevel', () => {
+  it('preserves headingLevel in read output after conversion', async () => {
+    const hwpFile = tempPath('hwp-convert-heading-level', '.hwp')
+    const hwpxFile = tempPath('hwpx-convert-heading-level', '.hwpx')
+
+    await runCliNoDaemon(['create', hwpFile])
+    await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpFile,
+      's0',
+      '변환 headingLevel 확인',
+      '--heading',
+      '3',
+      '--position',
+      'end',
+    ])
+    await runCliNoDaemon(['convert', hwpFile, hwpxFile])
+
+    const readResult = await runCliNoDaemon(['read', hwpxFile, '--pretty'])
+    const doc = parseOutput(readResult) as any
+    const para = doc.sections[0].paragraphs.find((p: any) => p.runs[0]?.text === '변환 headingLevel 확인')
+
+    expect(para).toBeDefined()
+    expect(para.headingLevel).toBe(3)
+    expect(para.styleName).toBe('개요 3')
+    expect(para.styleRef).toBe(3)
+  })
+})
+
+describe('Heading Styles — missing heading styles error', () => {
+  it('fails with descriptive error when heading styles are absent from HWPX', async () => {
+    const hwpxFile = tempPath('hwpx-no-heading-styles', '.hwpx')
+
+    // Create HWPX then strip heading styles from header.xml
+    await runCliNoDaemon(['create', hwpxFile])
+    const data = await readFile(hwpxFile)
+    const zip = await JSZip.loadAsync(data)
+    const headerXml = await zip.file('Contents/header.xml')?.async('string')
+    if (!headerXml) throw new Error('header.xml not found')
+
+    // Remove all heading style entries (개요 1-7), keep only Normal
+    const stripped = headerXml.replace(/<hh:style[^>]*hh:name="개요 \d"[^/]*\/>/g, '')
+    zip.file('Contents/header.xml', stripped)
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(hwpxFile, await zip.generateAsync({ type: 'nodebuffer' }))
+
+    const result = await runCliNoDaemon([
+      'paragraph',
+      'add',
+      hwpxFile,
+      's0',
+      '없는 스타일 테스트',
+      '--heading',
+      '1',
+      '--position',
+      'end',
+    ])
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('not found')
+  })
+})
+
+describe('Heading Styles — HWP→HWPX convert raw XML check', () => {
+  it('produces hh:heading with correct hh:level in header.xml after conversion', async () => {
+    const hwpFile = tempPath('hwp-convert-xml-check', '.hwp')
+    const hwpxFile = tempPath('hwpx-convert-xml-check', '.hwpx')
+
+    await runCliNoDaemon(['create', hwpFile])
+    await runCliNoDaemon(['paragraph', 'add', hwpFile, 's0', 'XML 검증 제목', '--heading', '2', '--position', 'end'])
+    await runCliNoDaemon(['convert', hwpFile, hwpxFile])
+
+    const data = await readFile(hwpxFile)
+    const zip = await JSZip.loadAsync(data)
+    const headerXml = await zip.file('Contents/header.xml')?.async('string')
+
+    expect(headerXml).toBeDefined()
+    expect(headerXml).toContain('<hh:heading')
+    expect(headerXml).toContain('hh:level="2"')
+    expect(headerXml).toContain('hh:type="OUTLINE"')
+  })
+})

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -4,10 +4,17 @@ import { basename, join } from 'node:path'
 import JSZip from 'jszip'
 
 /** Run the CLI as a real subprocess and capture output */
-export async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+export async function runCli(
+  args: string[],
+  options?: { env?: Record<string, string | undefined> },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn(['bun', 'src/cli.ts', ...args], {
     stdout: 'pipe',
     stderr: 'pipe',
+    env: {
+      ...process.env,
+      ...options?.env,
+    },
   })
 
   const stdout = await new Response(proc.stdout).text()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,13 +149,14 @@ paragraphCmd
   .command('add <file> <ref> <text>')
   .description('Add a new paragraph')
   .option('--position <pos>', 'Insertion position: before|after|end', 'end')
+  .option('--heading <level>', 'Set heading level (1-7)', (val: string) => parseInt(val, 10))
+  .option('--style <name>', 'Set paragraph style by name or ID')
   .option('--bold', 'Bold text')
   .option('--italic', 'Italic text')
   .option('--underline', 'Underline text')
   .option('--font <name>', 'Font name')
   .option('--size <n>', 'Font size in points', parseFloat)
   .option('--color <hex>', 'Text color (hex)')
-  .option('--pretty', 'Pretty-print JSON output')
   .action(
     async (
       file: string,
@@ -163,6 +164,8 @@ paragraphCmd
       text: string,
       options: {
         position?: string
+        heading?: number
+        style?: string | number
         bold?: boolean
         italic?: boolean
         underline?: boolean

--- a/src/commands/convert.test.ts
+++ b/src/commands/convert.test.ts
@@ -180,3 +180,183 @@ describe('generateHwpx', () => {
     expect(sections[0].paragraphs[0].runs[0].text).toBe('Hello')
   })
 })
+
+describe('generateHwpx - heading level and style type', () => {
+  it('writes hh:heading element with level attribute when paraShape has headingLevel > 0', async () => {
+    const doc: HwpDocument = {
+      format: 'hwp',
+      sections: [
+        {
+          paragraphs: [
+            {
+              ref: 's0.p0',
+              runs: [{ text: 'Heading 1', charShapeRef: 0 }],
+              paraShapeRef: 0,
+              styleRef: 0,
+            },
+          ],
+          tables: [],
+          images: [],
+        },
+      ],
+      header: {
+        fonts: [{ id: 0, name: '맑은 고딕' }],
+        charShapes: [
+          {
+            id: 0,
+            fontRef: 0,
+            fontSize: 10,
+            bold: false,
+            italic: false,
+            underline: false,
+            color: '#000000',
+          },
+        ],
+        paraShapes: [{ id: 0, align: 'left', headingLevel: 1 }],
+        styles: [{ id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0 }],
+      },
+    }
+
+    const hwpxBuffer = await generateHwpx(doc)
+    const zip = await JSZip.loadAsync(hwpxBuffer)
+    const headerXml = await zip.file('Contents/header.xml')?.async('text')
+
+    expect(headerXml).toBeDefined()
+    expect(headerXml).toContain('<hh:heading')
+    expect(headerXml).toContain('level="1"')
+    expect(headerXml).toContain('type="OUTLINE"')
+    expect(headerXml).toContain('idRef="0"')
+  })
+
+  it('does not write hh:heading element when paraShape has no headingLevel', async () => {
+    const doc: HwpDocument = {
+      format: 'hwp',
+      sections: [
+        {
+          paragraphs: [
+            {
+              ref: 's0.p0',
+              runs: [{ text: 'Body text', charShapeRef: 0 }],
+              paraShapeRef: 0,
+              styleRef: 0,
+            },
+          ],
+          tables: [],
+          images: [],
+        },
+      ],
+      header: {
+        fonts: [{ id: 0, name: '맑은 고딕' }],
+        charShapes: [
+          {
+            id: 0,
+            fontRef: 0,
+            fontSize: 10,
+            bold: false,
+            italic: false,
+            underline: false,
+            color: '#000000',
+          },
+        ],
+        paraShapes: [{ id: 0, align: 'left' }],
+        styles: [{ id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0 }],
+      },
+    }
+
+    const hwpxBuffer = await generateHwpx(doc)
+    const zip = await JSZip.loadAsync(hwpxBuffer)
+    const headerXml = await zip.file('Contents/header.xml')?.async('text')
+
+    expect(headerXml).toBeDefined()
+    expect(headerXml).not.toContain('<hh:heading')
+  })
+
+  it('writes type attribute on hh:style when style has type defined', async () => {
+    const doc: HwpDocument = {
+      format: 'hwp',
+      sections: [
+        {
+          paragraphs: [
+            {
+              ref: 's0.p0',
+              runs: [{ text: 'Test', charShapeRef: 0 }],
+              paraShapeRef: 0,
+              styleRef: 0,
+            },
+          ],
+          tables: [],
+          images: [],
+        },
+      ],
+      header: {
+        fonts: [{ id: 0, name: '맑은 고딕' }],
+        charShapes: [
+          {
+            id: 0,
+            fontRef: 0,
+            fontSize: 10,
+            bold: false,
+            italic: false,
+            underline: false,
+            color: '#000000',
+          },
+        ],
+        paraShapes: [{ id: 0, align: 'left' }],
+        styles: [{ id: 0, name: 'Heading 1', charShapeRef: 0, paraShapeRef: 0, type: 'PARA' }],
+      },
+    }
+
+    const hwpxBuffer = await generateHwpx(doc)
+    const zip = await JSZip.loadAsync(hwpxBuffer)
+    const headerXml = await zip.file('Contents/header.xml')?.async('text')
+
+    expect(headerXml).toBeDefined()
+    expect(headerXml).toContain('type="PARA"')
+  })
+
+  it('does not write type attribute on hh:style when style has no type', async () => {
+    const doc: HwpDocument = {
+      format: 'hwp',
+      sections: [
+        {
+          paragraphs: [
+            {
+              ref: 's0.p0',
+              runs: [{ text: 'Test', charShapeRef: 0 }],
+              paraShapeRef: 0,
+              styleRef: 0,
+            },
+          ],
+          tables: [],
+          images: [],
+        },
+      ],
+      header: {
+        fonts: [{ id: 0, name: '맑은 고딕' }],
+        charShapes: [
+          {
+            id: 0,
+            fontRef: 0,
+            fontSize: 10,
+            bold: false,
+            italic: false,
+            underline: false,
+            color: '#000000',
+          },
+        ],
+        paraShapes: [{ id: 0, align: 'left' }],
+        styles: [{ id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0 }],
+      },
+    }
+
+    const hwpxBuffer = await generateHwpx(doc)
+    const zip = await JSZip.loadAsync(hwpxBuffer)
+    const headerXml = await zip.file('Contents/header.xml')?.async('text')
+
+    expect(headerXml).toBeDefined()
+    // Should not have type attribute on style (only hh:id, hh:name, etc.)
+    const styleMatch = headerXml?.match(/<hh:style[^>]*>/)
+    expect(styleMatch).toBeDefined()
+    expect(styleMatch?.[0]).not.toContain('type=')
+  })
+})

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -126,13 +126,20 @@ function generateHeaderXml(header: DocumentHeader): string {
     .join('\n')
 
   const paraShapes = header.paraShapes
-    .map((paraShape) => `      <hh:paraPr ${generateParaShapeAttrs(paraShape)}/>`)
+    .map((paraShape) => {
+      const attrs = generateParaShapeAttrs(paraShape)
+      const headingElement = generateHeadingElement(paraShape)
+      const headingXml = headingElement ? `\n      ${headingElement}` : ''
+      return `      <hh:paraPr ${attrs}${headingXml}/>`
+    })
     .join('\n')
 
   const styles = header.styles
     .map(
-      (style) =>
-        `      <hh:style hh:id="${style.id}" hh:name="${escapeXml(style.name)}" hh:charPrIDRef="${style.charShapeRef}" hh:paraPrIDRef="${style.paraShapeRef}"/>`,
+      (style) => {
+        const typeAttr = style.type ? ` hh:type="${style.type}"` : ''
+        return `      <hh:style hh:id="${style.id}" hh:name="${escapeXml(style.name)}" hh:charPrIDRef="${style.charShapeRef}" hh:paraPrIDRef="${style.paraShapeRef}"${typeAttr}/>`
+      },
     )
     .join('\n')
 
@@ -231,6 +238,13 @@ function generateCharShapeAttrs(charShape: CharShape): string {
 
 function generateParaShapeAttrs(paraShape: ParaShape): string {
   return [`hh:id="${paraShape.id}"`, `hh:align="${toHwpxAlign(paraShape.align)}"`].join(' ')
+}
+
+function generateHeadingElement(paraShape: ParaShape): string | null {
+  if (!paraShape.headingLevel || paraShape.headingLevel <= 0) {
+    return null
+  }
+  return `<hh:heading hh:type="OUTLINE" hh:idRef="0" hh:level="${paraShape.headingLevel}"/>`
 }
 
 function toHwpxAlign(align: ParaShape['align']): 'LEFT' | 'CENTER' | 'RIGHT' | 'JUSTIFY' {

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -129,8 +129,9 @@ function generateHeaderXml(header: DocumentHeader): string {
     .map((paraShape) => {
       const attrs = generateParaShapeAttrs(paraShape)
       const headingElement = generateHeadingElement(paraShape)
-      const headingXml = headingElement ? `\n      ${headingElement}` : ''
-      return `      <hh:paraPr ${attrs}${headingXml}/>`
+      return headingElement
+        ? `      <hh:paraPr ${attrs}>\n        ${headingElement}\n      </hh:paraPr>`
+        : `      <hh:paraPr ${attrs}/>`
     })
     .join('\n')
 

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -135,12 +135,10 @@ function generateHeaderXml(header: DocumentHeader): string {
     .join('\n')
 
   const styles = header.styles
-    .map(
-      (style) => {
-        const typeAttr = style.type ? ` hh:type="${style.type}"` : ''
-        return `      <hh:style hh:id="${style.id}" hh:name="${escapeXml(style.name)}" hh:charPrIDRef="${style.charShapeRef}" hh:paraPrIDRef="${style.paraShapeRef}"${typeAttr}/>`
-      },
-    )
+    .map((style) => {
+      const typeAttr = style.type ? ` hh:type="${style.type}"` : ''
+      return `      <hh:style hh:id="${style.id}" hh:name="${escapeXml(style.name)}" hh:charPrIDRef="${style.charShapeRef}" hh:paraPrIDRef="${style.paraShapeRef}"${typeAttr}/>`
+    })
     .join('\n')
 
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { afterEach, expect, it, mock } from 'bun:test'
 import { unlink } from 'node:fs/promises'
 import { loadHwp } from '@/formats/hwp/reader'
 import { loadHwpx } from '@/formats/hwpx/loader'
@@ -150,10 +150,9 @@ describe('createCommand', () => {
   })
 })
 
-import { describe, expect, it } from 'bun:test'
 import JSZip from 'jszip'
-import { createTestHwpx } from '@/test-helpers'
 import { parseHeader } from '@/formats/hwpx/header-parser'
+import { createTestHwpx } from '@/test-helpers'
 
 describe('createTestHwpx — heading styles', () => {
   async function getHeader() {

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it, mock } from 'bun:test'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { unlink } from 'node:fs/promises'
 import { loadHwp } from '@/formats/hwp/reader'
 import { loadHwpx } from '@/formats/hwpx/loader'

--- a/src/commands/paragraph.test.ts
+++ b/src/commands/paragraph.test.ts
@@ -109,4 +109,69 @@ describe('paragraphAddCommand', () => {
     const output = JSON.parse(logs[0])
     expect(output.success).toBe(true)
   })
+
+  it('--heading 1 sets heading in operation', async () => {
+    captureOutput()
+    await paragraphAddCommand(TEST_FILE, 's0', 'Heading text', { heading: 1 })
+    restoreOutput()
+
+    const output = JSON.parse(logs[0])
+    expect(output.success).toBe(true)
+  })
+
+  it('--heading 3 sets heading in operation', async () => {
+    captureOutput()
+    await paragraphAddCommand(TEST_FILE, 's0', 'Heading text', { heading: 3 })
+    restoreOutput()
+
+    const output = JSON.parse(logs[0])
+    expect(output.success).toBe(true)
+  })
+
+  it('--style "개요 2" sets style by name', async () => {
+    captureOutput()
+    await paragraphAddCommand(TEST_FILE, 's0', 'Styled text', { style: '개요 2' })
+    restoreOutput()
+
+    const output = JSON.parse(logs[0])
+    expect(output.success).toBe(true)
+  })
+
+  it('--style 3 sets style by numeric ID', async () => {
+    captureOutput()
+    await paragraphAddCommand(TEST_FILE, 's0', 'Styled text', { style: 3 })
+    restoreOutput()
+
+    const output = JSON.parse(logs[0])
+    expect(output.success).toBe(true)
+  })
+
+  it('--heading 1 --style "개요 1" simultaneously rejects', async () => {
+    captureOutput()
+    await expect(paragraphAddCommand(TEST_FILE, 's0', 'Text', { heading: 1, style: '개요 1' })).rejects.toThrow(
+      'process.exit',
+    )
+    restoreOutput()
+
+    const output = JSON.parse(errors[0])
+    expect(output.error).toContain('Cannot specify both --heading and --style')
+  })
+
+  it('--heading 0 rejects (invalid level)', async () => {
+    captureOutput()
+    await expect(paragraphAddCommand(TEST_FILE, 's0', 'Text', { heading: 0 })).rejects.toThrow('process.exit')
+    restoreOutput()
+
+    const output = JSON.parse(errors[0])
+    expect(output.error).toContain('Heading level must be between 1 and 7')
+  })
+
+  it('--heading 8 rejects (out of range)', async () => {
+    captureOutput()
+    await expect(paragraphAddCommand(TEST_FILE, 's0', 'Text', { heading: 8 })).rejects.toThrow('process.exit')
+    restoreOutput()
+
+    const output = JSON.parse(errors[0])
+    expect(output.error).toContain('Heading level must be between 1 and 7')
+  })
 })

--- a/src/commands/paragraph.ts
+++ b/src/commands/paragraph.ts
@@ -16,6 +16,8 @@ type ParagraphAddCommandOptions = {
   font?: string
   size?: number
   color?: string
+  heading?: number
+  style?: string | number
   pretty?: boolean
 }
 
@@ -33,6 +35,18 @@ export async function paragraphAddCommand(
       throw new Error(`Invalid position: ${position}. Must be 'before', 'after', or 'end'`)
     }
 
+    // Validate heading and style are mutually exclusive
+    if (options.heading !== undefined && options.style !== undefined) {
+      throw new Error('Cannot specify both --heading and --style')
+    }
+
+    // Validate heading level
+    if (options.heading !== undefined) {
+      if (options.heading < 1 || options.heading > 7) {
+        throw new Error('Heading level must be between 1 and 7')
+      }
+    }
+
     // Build format object from options
     const format: FormatOptions = {}
     if (options.bold !== undefined) format.bold = options.bold
@@ -47,6 +61,8 @@ export async function paragraphAddCommand(
       text,
       position,
       format: Object.keys(format).length > 0 ? format : undefined,
+      heading: options.heading,
+      style: options.style,
     })
 
     if (daemonResult !== null) {
@@ -79,6 +95,8 @@ export async function paragraphAddCommand(
           text,
           position: position as 'before' | 'after' | 'end',
           format: Object.keys(format).length > 0 ? format : undefined,
+          heading: options.heading,
+          style: options.style,
         },
       ])
     } else {
@@ -89,6 +107,8 @@ export async function paragraphAddCommand(
           text,
           position: position as 'before' | 'after' | 'end',
           format: Object.keys(format).length > 0 ? format : undefined,
+          heading: options.heading,
+          style: options.style,
         },
       ])
     }

--- a/src/commands/paragraph.ts
+++ b/src/commands/paragraph.ts
@@ -47,6 +47,12 @@ export async function paragraphAddCommand(
       }
     }
 
+    // Coerce numeric style string to number for ID-based lookup
+    const styleValue =
+      options.style !== undefined && /^\d+$/.test(String(options.style))
+        ? parseInt(String(options.style), 10)
+        : options.style
+
     // Build format object from options
     const format: FormatOptions = {}
     if (options.bold !== undefined) format.bold = options.bold
@@ -62,7 +68,7 @@ export async function paragraphAddCommand(
       position,
       format: Object.keys(format).length > 0 ? format : undefined,
       heading: options.heading,
-      style: options.style,
+      style: styleValue,
     })
 
     if (daemonResult !== null) {
@@ -96,7 +102,7 @@ export async function paragraphAddCommand(
           position: position as 'before' | 'after' | 'end',
           format: Object.keys(format).length > 0 ? format : undefined,
           heading: options.heading,
-          style: options.style,
+          style: styleValue,
         },
       ])
     } else {
@@ -108,7 +114,7 @@ export async function paragraphAddCommand(
           position: position as 'before' | 'after' | 'end',
           format: Object.keys(format).length > 0 ? format : undefined,
           heading: options.heading,
-          style: options.style,
+          style: styleValue,
         },
       ])
     }

--- a/src/commands/read.test.ts
+++ b/src/commands/read.test.ts
@@ -328,7 +328,7 @@ describe('readCommand — heading level and style name resolution', () => {
       'version.xml',
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <hv:version xmlns:hv="http://www.hancom.co.kr/hwpml/2011/version"
-  major="5" minor="1" micro="0" buildNumber="0"/>`
+  major="5" minor="1" micro="0" buildNumber="0"/>`,
     )
 
     zip.file(
@@ -338,7 +338,7 @@ describe('readCommand — heading level and style name resolution', () => {
   <manifest:file-entry manifest:full-path="/" manifest:media-type="application/hwp+zip"/>
   <manifest:file-entry manifest:full-path="Contents/header.xml" manifest:media-type="text/xml"/>
   <manifest:file-entry manifest:full-path="Contents/section0.xml" manifest:media-type="text/xml"/>
-</manifest:manifest>`
+</manifest:manifest>`,
     )
 
     zip.file(
@@ -352,7 +352,7 @@ describe('readCommand — heading level and style name resolution', () => {
   <opf:spine>
     <opf:itemref idref="section0"/>
   </opf:spine>
-</opf:package>`
+</opf:package>`,
     )
 
     // Header with heading style (id=1) and body style (id=0)
@@ -379,7 +379,7 @@ describe('readCommand — heading level and style name resolution', () => {
       <hh:style hh:id="1" hh:name="Heading 1" hh:charPrIDRef="0" hh:paraPrIDRef="1" hh:type="PARA"/>
     </hh:styles>
   </hh:refList>
-</hh:head>`
+</hh:head>`,
     )
 
     // Section with two paragraphs: one with heading style, one with body style
@@ -396,7 +396,7 @@ describe('readCommand — heading level and style name resolution', () => {
   <hp:p hp:id="1" hp:paraPrIDRef="0" hp:styleIDRef="0">
     <hp:run hp:charPrIDRef="0"><hp:t>Body Text</hp:t></hp:run>
   </hp:p>
-</hs:sec>`
+</hs:sec>`,
     )
 
     const buffer = await zip.generateAsync({ type: 'nodebuffer' })

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -89,7 +89,7 @@ function enrichParagraph(
   para: Paragraph,
   header: DocumentHeader,
 ): Paragraph & { headingLevel?: number; styleName?: string } {
-  const enriched: any = { ...para }
+  const enriched: Paragraph & { headingLevel?: number; styleName?: string } = { ...para }
 
   // Resolve heading level from paraShapeRef
   const paraShape = header.paraShapes.find((ps) => ps.id === para.paraShapeRef)

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -7,6 +7,7 @@ import { resolveRef } from '@/shared/document-ops'
 import { handleError } from '@/shared/error-handler'
 import { detectFormat } from '@/shared/format-detector'
 import { formatOutput } from '@/shared/output'
+import { DocumentHeader, Paragraph } from '@/types'
 
 type ReadOptions = {
   pretty?: boolean
@@ -40,11 +41,17 @@ export async function readCommand(file: string, ref: string | undefined, options
     const format = await detectFormat(file)
     const doc = format === 'hwp' ? await loadHwp(file) : await loadHwpxDocument(file)
 
-    if (ref) {
+if (ref) {
       const result = resolveRef(ref, doc.sections)
+      // Enrich paragraph results with heading level and style name
+      if (result && typeof result === 'object' && 'ref' in result && 'runs' in result) {
+        const enriched = enrichParagraph(result as Paragraph, doc.header)
+        console.log(formatOutput(enriched, options.pretty))
+      } else {
       console.log(formatOutput(result, options.pretty))
-      return
-    }
+      }
+return
+}
 
     const hasPagination = options.offset !== undefined || options.limit !== undefined
     const offset = options.offset ?? 0
@@ -63,7 +70,7 @@ export async function readCommand(file: string, ref: string | undefined, options
             totalImages: section.images.length,
             totalTextBoxes: section.textBoxes.length,
           }),
-          paragraphs,
+          paragraphs: paragraphs.map(p => enrichParagraph(p, doc.header)),
           tables: section.tables,
           images: section.images,
           textBoxes: section.textBoxes,
@@ -76,6 +83,24 @@ export async function readCommand(file: string, ref: string | undefined, options
   } catch (e) {
     handleError(e)
   }
+}
+
+function enrichParagraph(para: Paragraph, header: DocumentHeader): Paragraph & { headingLevel?: number; styleName?: string } {
+  const enriched: any = { ...para }
+
+  // Resolve heading level from paraShapeRef
+  const paraShape = header.paraShapes.find(ps => ps.id === para.paraShapeRef)
+  if (paraShape?.headingLevel && paraShape.headingLevel > 0) {
+    enriched.headingLevel = paraShape.headingLevel
+  }
+
+  // Resolve style name from styleRef
+  const style = header.styles.find(s => s.id === para.styleRef)
+  if (style) {
+    enriched.styleName = style.name
+  }
+
+  return enriched
 }
 
 async function loadHwpxDocument(file: string) {

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -41,17 +41,17 @@ export async function readCommand(file: string, ref: string | undefined, options
     const format = await detectFormat(file)
     const doc = format === 'hwp' ? await loadHwp(file) : await loadHwpxDocument(file)
 
-if (ref) {
+    if (ref) {
       const result = resolveRef(ref, doc.sections)
       // Enrich paragraph results with heading level and style name
       if (result && typeof result === 'object' && 'ref' in result && 'runs' in result) {
         const enriched = enrichParagraph(result as Paragraph, doc.header)
         console.log(formatOutput(enriched, options.pretty))
       } else {
-      console.log(formatOutput(result, options.pretty))
+        console.log(formatOutput(result, options.pretty))
       }
-return
-}
+      return
+    }
 
     const hasPagination = options.offset !== undefined || options.limit !== undefined
     const offset = options.offset ?? 0
@@ -70,7 +70,7 @@ return
             totalImages: section.images.length,
             totalTextBoxes: section.textBoxes.length,
           }),
-          paragraphs: paragraphs.map(p => enrichParagraph(p, doc.header)),
+          paragraphs: paragraphs.map((p) => enrichParagraph(p, doc.header)),
           tables: section.tables,
           images: section.images,
           textBoxes: section.textBoxes,
@@ -85,17 +85,20 @@ return
   }
 }
 
-function enrichParagraph(para: Paragraph, header: DocumentHeader): Paragraph & { headingLevel?: number; styleName?: string } {
+function enrichParagraph(
+  para: Paragraph,
+  header: DocumentHeader,
+): Paragraph & { headingLevel?: number; styleName?: string } {
   const enriched: any = { ...para }
 
   // Resolve heading level from paraShapeRef
-  const paraShape = header.paraShapes.find(ps => ps.id === para.paraShapeRef)
+  const paraShape = header.paraShapes.find((ps) => ps.id === para.paraShapeRef)
   if (paraShape?.headingLevel && paraShape.headingLevel > 0) {
     enriched.headingLevel = paraShape.headingLevel
   }
 
   // Resolve style name from styleRef
-  const style = header.styles.find(s => s.id === para.styleRef)
+  const style = header.styles.find((s) => s.id === para.styleRef)
   if (style) {
     enriched.styleName = style.name
   }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -382,7 +382,10 @@ function enrichReadResult(resolved: unknown, header: DocumentHeader): unknown {
   return resolved
 }
 
-function enrichParagraph(para: Paragraph, header: DocumentHeader): Paragraph & { headingLevel?: number; styleName?: string } {
+function enrichParagraph(
+  para: Paragraph,
+  header: DocumentHeader,
+): Paragraph & { headingLevel?: number; styleName?: string } {
   const enriched: Paragraph & { headingLevel?: number; styleName?: string } = { ...para }
 
   const paraShape = header.paraShapes.find((shape) => shape.id === para.paraShapeRef)

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -282,8 +282,10 @@ async function handleRequest(
         const text = stringArg(msg.args.text, 'text')
         const position = stringArg(msg.args.position, 'position')
         const format = msg.args.format as FormatOptions | undefined
+        const heading = msg.args.heading as number | undefined
+        const style = msg.args.style as string | number | undefined
         await holder.applyOperations([
-          { type: 'addParagraph', ref, text, position: position as 'before' | 'after' | 'end', format },
+          { type: 'addParagraph', ref, text, position: position as 'before' | 'after' | 'end', format, heading, style },
         ])
         await scheduler.flushNow()
         return { success: true, data: { ref, text, position, success: true } }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -18,6 +18,7 @@ import {
 } from '@/shared/document-ops'
 import type { FormatOptions } from '@/shared/edit-types'
 import { detectFormat } from '@/shared/format-detector'
+import type { DocumentHeader, Paragraph } from '@/types'
 
 const DEFAULT_IDLE_MS = 15 * 60 * 1000
 const DEFAULT_FLUSH_MS = 500
@@ -162,14 +163,15 @@ async function handleRequest(
     switch (msg.command) {
       case 'read': {
         const ref = typeof msg.args.ref === 'string' ? msg.args.ref : undefined
+        const header = await holder.getHeader()
         if (ref) {
-          return { success: true, data: resolveRef(ref, sections) }
+          const resolved = resolveRef(ref, sections)
+          return { success: true, data: enrichReadResult(resolved, header) }
         }
 
         const offset = numberArg(msg.args.offset, 0)
         const limit = numberArg(msg.args.limit, Number.POSITIVE_INFINITY)
         const hasPagination = msg.args.offset !== undefined || msg.args.limit !== undefined
-        const header = await holder.getHeader()
 
         return {
           success: true,
@@ -186,7 +188,7 @@ async function handleRequest(
                   totalImages: section.images.length,
                   totalTextBoxes: section.textBoxes.length,
                 }),
-                paragraphs,
+                paragraphs: paragraphs.map((paragraph) => enrichParagraph(paragraph, header)),
                 tables: section.tables,
                 images: section.images,
                 textBoxes: section.textBoxes,
@@ -366,4 +368,32 @@ function isValidRequest(msg: unknown): msg is { token: string; command: string; 
     typeof (msg as { args: unknown }).args === 'object' &&
     (msg as { args: unknown }).args !== null
   )
+}
+
+function enrichReadResult(resolved: unknown, header: DocumentHeader): unknown {
+  if (!resolved || typeof resolved !== 'object') {
+    return resolved
+  }
+
+  if ('ref' in resolved && 'runs' in resolved) {
+    return enrichParagraph(resolved as Paragraph, header)
+  }
+
+  return resolved
+}
+
+function enrichParagraph(para: Paragraph, header: DocumentHeader): Paragraph & { headingLevel?: number; styleName?: string } {
+  const enriched: Paragraph & { headingLevel?: number; styleName?: string } = { ...para }
+
+  const paraShape = header.paraShapes.find((shape) => shape.id === para.paraShapeRef)
+  if (paraShape?.headingLevel && paraShape.headingLevel > 0) {
+    enriched.headingLevel = paraShape.headingLevel
+  }
+
+  const style = header.styles.find((item) => item.id === para.styleRef)
+  if (style) {
+    enriched.styleName = style.name
+  }
+
+  return enriched
 }

--- a/src/formats/hwp/creator.ts
+++ b/src/formats/hwp/creator.ts
@@ -107,6 +107,8 @@ function patchDocInfo(
   const parts: Buffer[] = []
   let faceNameIndex = 0
   let charShapeIndex = 0
+  let paraShapeIndex = 0
+  let styleIndex = 0
   for (const { header, data, offset } of iterateRecords(stream)) {
     const recordBuf = stream.subarray(offset, offset + header.headerSize + header.size)
     if (header.tagId === TAG.FACE_NAME && font) {
@@ -125,16 +127,64 @@ function patchDocInfo(
         if (font) patched.writeUInt16LE(0, 0)
         if (fontSize) patched.writeUInt32LE(fontSize, 42)
         parts.push(buildRecord(TAG.CHAR_SHAPE, header.level, patched))
+        // Add 7 heading charShapes after body
+        for (const headingCharShape of buildHeadingCharShapes(data)) {
+          parts.push(buildRecord(TAG.CHAR_SHAPE, header.level, headingCharShape))
+        }
       }
       charShapeIndex++
+      continue
+    }
+
+    if (header.tagId === TAG.PARA_SHAPE) {
+      if (paraShapeIndex === 0) {
+        parts.push(recordBuf)
+        // Add 7 heading paraShapes after body
+        for (const headingParaShape of buildHeadingParaShapes()) {
+          parts.push(buildRecord(TAG.PARA_SHAPE, header.level, headingParaShape))
+        }
+      }
+      paraShapeIndex++
+      continue
+    }
+
+    if (header.tagId === TAG.STYLE) {
+      if (styleIndex === 0) {
+        // Patch body style refs to 0/0
+        const patched = Buffer.from(data)
+        const nameLen = patched.readUInt16LE(0)
+        let refOffset = 2 + nameLen * 2
+        if (refOffset + 2 <= patched.length) {
+          const englishNameLen = patched.readUInt16LE(refOffset)
+          refOffset += 2 + englishNameLen * 2
+        }
+        if (refOffset + 4 <= patched.length) {
+          patched.writeUInt16LE(0, refOffset)     // charShapeRef = 0
+          patched.writeUInt16LE(0, refOffset + 2)  // paraShapeRef = 0
+        }
+        parts.push(buildRecord(TAG.STYLE, header.level, patched))
+        // Add 7 heading styles after body
+        for (const headingStyle of buildHeadingStyles()) {
+          parts.push(buildRecord(TAG.STYLE, header.level, headingStyle))
+        }
+      }
+      styleIndex++
       continue
     }
 
     if (header.tagId === TAG.ID_MAPPINGS) {
       const patched = Buffer.from(data)
       const charShapeByteOffset = 9 * 4
+      const paraShapeByteOffset = 13 * 4
+      const styleByteOffset = 14 * 4
       if (patched.length >= charShapeByteOffset + 4) {
-        patched.writeUInt32LE(1, charShapeByteOffset)
+        patched.writeUInt32LE(8, charShapeByteOffset)
+      }
+      if (patched.length >= paraShapeByteOffset + 4) {
+        patched.writeUInt32LE(8, paraShapeByteOffset)
+      }
+      if (patched.length >= styleByteOffset + 4) {
+        patched.writeUInt32LE(8, styleByteOffset)
       }
       parts.push(buildRecord(header.tagId, header.level, patched))
       continue
@@ -144,6 +194,42 @@ function patchDocInfo(
   }
 
   return { docInfo: Buffer.concat(parts) }
+}
+
+const HEADING_FONT_SIZES = [2200, 1800, 1600, 1400, 1300, 1200, 1100]
+
+function buildHeadingCharShapes(bodyCharShapeData: Buffer): Buffer[] {
+  return HEADING_FONT_SIZES.map((size) => {
+    const cs = Buffer.from(bodyCharShapeData)
+    cs.writeUInt32LE(size, 42)
+    // Set bold bit (bit 0) in attribute flags at offset 46
+    const attrBits = cs.readUInt32LE(46)
+    cs.writeUInt32LE((attrBits | 0x1) >>> 0, 46)
+    return cs
+  })
+}
+
+function buildHeadingParaShapes(): Buffer[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const level = i + 1
+    const buf = Buffer.alloc(4)
+    // bits 2-4: alignment=1 (left), bits 25-27: heading level
+    buf.writeUInt32LE(((level << 25) | (1 << 2)) >>> 0, 0)
+    return buf
+  })
+}
+
+function buildHeadingStyles(): Buffer[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const level = i + 1
+    const koreanName = encodeLengthPrefixedUtf16(`\uAC1C\uC694 ${level}`)
+    const englishNameLen = Buffer.alloc(2)
+    englishNameLen.writeUInt16LE(0, 0)
+    const refs = Buffer.alloc(4)
+    refs.writeUInt16LE(level, 0) // charShapeRef
+    refs.writeUInt16LE(level, 2) // paraShapeRef
+    return Buffer.concat([koreanName, englishNameLen, refs])
+  })
 }
 
 function encodeLengthPrefixedUtf16(text: string): Buffer {

--- a/src/formats/hwp/creator.ts
+++ b/src/formats/hwp/creator.ts
@@ -159,8 +159,8 @@ function patchDocInfo(
           refOffset += 2 + englishNameLen * 2
         }
         if (refOffset + 4 <= patched.length) {
-          patched.writeUInt16LE(0, refOffset)     // charShapeRef = 0
-          patched.writeUInt16LE(0, refOffset + 2)  // paraShapeRef = 0
+          patched.writeUInt16LE(0, refOffset) // charShapeRef = 0
+          patched.writeUInt16LE(0, refOffset + 2) // paraShapeRef = 0
         }
         parts.push(buildRecord(TAG.STYLE, header.level, patched))
         // Add 7 heading styles after body

--- a/src/formats/hwp/mutator.test.ts
+++ b/src/formats/hwp/mutator.test.ts
@@ -671,11 +671,7 @@ describe('mutateHwpCfb addParagraph heading/style', () => {
       const cfb = CFB.read(buffer, { type: 'buffer' })
       const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
 
-      mutateHwpCfb(
-        cfb,
-        [{ type: 'addParagraph', ref: 's0', text: 'Styled', position: 'end', style: 4 }],
-        compressed,
-      )
+      mutateHwpCfb(cfb, [{ type: 'addParagraph', ref: 's0', text: 'Styled', position: 'end', style: 4 }], compressed)
 
       const headerData = await getParagraphHeaderData(cfb, compressed, 1)
       expect(headerData).not.toBeNull()
@@ -715,11 +711,7 @@ describe('mutateHwpCfb addParagraph heading/style', () => {
     const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
 
     expect(() => {
-      mutateHwpCfb(
-        cfb,
-        [{ type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 1 }],
-        compressed,
-      )
+      mutateHwpCfb(cfb, [{ type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 1 }], compressed)
     }).toThrow('개요 1')
   })
 
@@ -732,11 +724,7 @@ describe('mutateHwpCfb addParagraph heading/style', () => {
       const cfb = CFB.read(buffer, { type: 'buffer' })
       const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
 
-      mutateHwpCfb(
-        cfb,
-        [{ type: 'addParagraph', ref: 's0', text: 'Plain', position: 'end' }],
-        compressed,
-      )
+      mutateHwpCfb(cfb, [{ type: 'addParagraph', ref: 's0', text: 'Plain', position: 'end' }], compressed)
 
       const headerData = await getParagraphHeaderData(cfb, compressed, 1)
       expect(headerData).not.toBeNull()

--- a/src/formats/hwp/mutator.test.ts
+++ b/src/formats/hwp/mutator.test.ts
@@ -551,3 +551,199 @@ describe('mutateHwpCfb addParagraph', () => {
     }
   })
 })
+
+async function getParagraphHeaderData(
+  cfb: CFB.CFB$Container,
+  compressed: boolean,
+  paragraphTarget: number,
+): Promise<Buffer | null> {
+  let sectionStream = getEntryBuffer(cfb, '/BodyText/Section0')
+  if (compressed) {
+    const { decompressStream } = await import('./stream-util')
+    sectionStream = decompressStream(sectionStream)
+  }
+
+  let paragraphIndex = -1
+  for (const { header, data } of iterateRecords(sectionStream)) {
+    if (header.tagId === TAG.PARA_HEADER && header.level === 0) {
+      paragraphIndex += 1
+      if (paragraphIndex === paragraphTarget) {
+        return data
+      }
+    }
+  }
+
+  return null
+}
+
+describe('mutateHwpCfb addParagraph heading/style', () => {
+  const readParagraphTexts = async (path: string): Promise<string[]> => {
+    const doc = await loadHwp(path)
+    return doc.sections[0].paragraphs.map((paragraph) => paragraph.runs.map((run) => run.text).join(''))
+  }
+
+  it('sets paraShapeRef and styleRef when heading is specified', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-heading')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Heading 1', position: 'end', heading: 1 }],
+        compressed,
+      )
+
+      // Paragraph 0 is the empty initial paragraph, paragraph 1 is the new one
+      const headerData = await getParagraphHeaderData(cfb, compressed, 1)
+      expect(headerData).not.toBeNull()
+      // byte 8: paraShapeRef (uint16) = 1 (개요 1 paraShape)
+      expect(headerData!.readUInt16LE(8)).toBe(1)
+      // byte 10: styleRef (uint8) = 1 (개요 1 style index)
+      expect(headerData!.readUInt8(10)).toBe(1)
+
+      await writeFile(hwpPath, Buffer.from(CFB.write(cfb, { type: 'buffer' })))
+      const texts = await readParagraphTexts(hwpPath)
+      expect(texts).toContain('Heading 1')
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+
+  it('sets paraShapeRef and styleRef for heading level 3', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-heading3')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Heading 3', position: 'end', heading: 3 }],
+        compressed,
+      )
+
+      const headerData = await getParagraphHeaderData(cfb, compressed, 1)
+      expect(headerData).not.toBeNull()
+      expect(headerData!.readUInt16LE(8)).toBe(3)
+      expect(headerData!.readUInt8(10)).toBe(3)
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+
+  it('looks up style by name', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-style-name')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Styled', position: 'end', style: '개요 2' }],
+        compressed,
+      )
+
+      const headerData = await getParagraphHeaderData(cfb, compressed, 1)
+      expect(headerData).not.toBeNull()
+      // 개요 2 is style index 2, paraShapeRef=2
+      expect(headerData!.readUInt16LE(8)).toBe(2)
+      expect(headerData!.readUInt8(10)).toBe(2)
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+
+  it('looks up style by numeric ID', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-style-id')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Styled', position: 'end', style: 4 }],
+        compressed,
+      )
+
+      const headerData = await getParagraphHeaderData(cfb, compressed, 1)
+      expect(headerData).not.toBeNull()
+      // Style index 4 = 개요 4, paraShapeRef=4
+      expect(headerData!.readUInt16LE(8)).toBe(4)
+      expect(headerData!.readUInt8(10)).toBe(4)
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+
+  it('throws when both heading and style are specified', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-heading-style-conflict')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      expect(() => {
+        mutateHwpCfb(
+          cfb,
+          [{ type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 1, style: '개요 1' }],
+          compressed,
+        )
+      }).toThrow('Cannot specify both heading and style')
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+
+  it('throws when heading style not found in document', async () => {
+    // createTestHwpBinary only has 'Normal' style, no heading styles
+    const buf = await createTestHwpBinary({ paragraphs: ['Hello'] })
+    const cfb = CFB.read(buf, { type: 'buffer' })
+    const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+    expect(() => {
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 1 }],
+        compressed,
+      )
+    }).toThrow('개요 1')
+  })
+
+  it('defaults to paraShapeRef=0 and styleRef=0 without heading/style', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-default-refs')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Plain', position: 'end' }],
+        compressed,
+      )
+
+      const headerData = await getParagraphHeaderData(cfb, compressed, 1)
+      expect(headerData).not.toBeNull()
+      expect(headerData!.readUInt16LE(8)).toBe(0)
+      expect(headerData!.readUInt8(10)).toBe(0)
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+})

--- a/src/formats/hwp/reader.test.ts
+++ b/src/formats/hwp/reader.test.ts
@@ -588,3 +588,93 @@ describe('STYLE record parsing', () => {
     await Bun.file(filePath).delete()
   })
 })
+
+// Test for PARA_SHAPE record with heading level
+describe('PARA_SHAPE record parsing', () => {
+  it('parses PARA_SHAPE with heading level 1 set in bits 25-27', async () => {
+    const filePath = '/tmp/test-hwp-para-shape-heading-1.hwp'
+    const _TMP_FILES: string[] = [filePath]
+
+    // Build PARA_SHAPE record with heading level 1 in bits 25-27
+    // First DWORD: bits 25-27 = 1 (heading level 1)
+    // Bits 25-27 means: (1 << 25) = 0x02000000
+    const dword = Buffer.alloc(4)
+    dword.writeUInt32LE(0x02000000, 0) // heading level 1 in bits 25-27
+
+    const paraShapeData = dword
+
+    const docInfoRecords = buildRecord(TAG.PARA_SHAPE, 1, paraShapeData)
+    const sectionRecords = Buffer.concat([
+      buildRecord(TAG.PARA_HEADER, 0, Buffer.alloc(0)),
+      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([0x0000])),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, docInfoRecords, sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const paraShape = doc.header.paraShapes[0]
+
+    expect(paraShape.headingLevel).toBe(1)
+
+    // Cleanup
+    await Bun.file(filePath).delete()
+  })
+
+  it('parses PARA_SHAPE with heading level 0 (body text) as undefined', async () => {
+    const filePath = '/tmp/test-hwp-para-shape-heading-0.hwp'
+    const _TMP_FILES: string[] = [filePath]
+
+    // Build PARA_SHAPE record with heading level 0 (body text)
+    const dword = Buffer.alloc(4)
+    dword.writeUInt32LE(0x00000000, 0) // heading level 0 (body text)
+
+    const paraShapeData = dword
+
+    const docInfoRecords = buildRecord(TAG.PARA_SHAPE, 1, paraShapeData)
+    const sectionRecords = Buffer.concat([
+      buildRecord(TAG.PARA_HEADER, 0, Buffer.alloc(0)),
+      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([0x0000])),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, docInfoRecords, sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const paraShape = doc.header.paraShapes[0]
+
+    expect(paraShape.headingLevel).toBeUndefined()
+
+    // Cleanup
+    await Bun.file(filePath).delete()
+  })
+
+  it('parses PARA_SHAPE with heading level 3 set in bits 25-27', async () => {
+    const filePath = '/tmp/test-hwp-para-shape-heading-3.hwp'
+    const _TMP_FILES: string[] = [filePath]
+
+    // Build PARA_SHAPE record with heading level 3 in bits 25-27
+    // Bits 25-27 = 3 means: (3 << 25) = 0x06000000
+    const dword = Buffer.alloc(4)
+    dword.writeUInt32LE(0x06000000, 0) // heading level 3 in bits 25-27
+
+    const paraShapeData = dword
+
+    const docInfoRecords = buildRecord(TAG.PARA_SHAPE, 1, paraShapeData)
+    const sectionRecords = Buffer.concat([
+      buildRecord(TAG.PARA_HEADER, 0, Buffer.alloc(0)),
+      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([0x0000])),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, docInfoRecords, sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const paraShape = doc.header.paraShapes[0]
+
+    expect(paraShape.headingLevel).toBe(3)
+
+    // Cleanup
+    await Bun.file(filePath).delete()
+  })
+})

--- a/src/formats/hwp/reader.test.ts
+++ b/src/formats/hwp/reader.test.ts
@@ -542,7 +542,7 @@ function shapePictureData(binId: number, noiseIdAtZero = 0): Buffer {
 describe('STYLE record parsing', () => {
   it('parses STYLE record with non-empty English name correctly', async () => {
     const filePath = '/tmp/test-hwp-style-english-name.hwp'
-    const TMP_FILES: string[] = [filePath]
+    const _TMP_FILES: string[] = [filePath]
 
     // Build STYLE record with Korean name "스타일" and English name "Heading 1"
     const koreanName = Buffer.from('스타일', 'utf16le')

--- a/src/formats/hwp/reader.ts
+++ b/src/formats/hwp/reader.ts
@@ -233,14 +233,20 @@ function parseDocInfo(buffer: Buffer): DocInfoParseResult {
       }
 
       const nameLen = data.readUInt16LE(0)
-      const baseOffset = 2 + nameLen * 2
-      if (baseOffset + 6 > data.length) {
+      let offset = 2 + nameLen * 2
+      // Skip English name if present
+      if (offset + 2 <= data.length) {
+        const englishNameLen = data.readUInt16LE(offset)
+        offset += 2 + englishNameLen * 2
+      }
+
+      if (offset + 4 > data.length) {
         continue
       }
 
-      const name = data.subarray(2, baseOffset).toString('utf16le')
-      const charShapeRef = data.readUInt16LE(baseOffset + 2)
-      const paraShapeRef = data.readUInt16LE(baseOffset + 4)
+      const name = data.subarray(2, 2 + nameLen * 2).toString('utf16le')
+      const charShapeRef = data.readUInt16LE(offset)
+      const paraShapeRef = data.readUInt16LE(offset + 2)
       styles.push({ id: styleId, name, charShapeRef, paraShapeRef })
       styleId += 1
     }

--- a/src/formats/hwp/reader.ts
+++ b/src/formats/hwp/reader.ts
@@ -215,14 +215,20 @@ function parseDocInfo(buffer: Buffer): DocInfoParseResult {
         continue
       }
 
-      const alignBits = data.readUInt32LE(0) & 0x3
+      const dword = data.readUInt32LE(0)
+      const alignBits = dword & 0x3
+      const headingLevelBits = (dword >>> 25) & 0x7
       const alignMap: Record<number, 'left' | 'right' | 'center' | 'justify'> = {
         0: 'justify',
         1: 'left',
         2: 'right',
         3: 'center',
       }
-      paraShapes.push({ id: paraShapeId, align: alignMap[alignBits] ?? 'left' })
+      const paraShape: ParaShape = { id: paraShapeId, align: alignMap[alignBits] ?? 'left' }
+      if (headingLevelBits > 0) {
+        paraShape.headingLevel = headingLevelBits
+      }
+      paraShapes.push(paraShape)
       paraShapeId += 1
       continue
     }

--- a/src/formats/hwpx/header-parser.test.ts
+++ b/src/formats/hwpx/header-parser.test.ts
@@ -69,6 +69,84 @@ describe('parseHeader', () => {
     expect(header.styles[1]).toEqual({ id: 1, name: 'Heading 1', charShapeRef: 1, paraShapeRef: 1 })
   })
 
+  it('parses paraShapes with heading level', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:paraProperties>
+      <hh:paraPr hh:id="0" hh:align="LEFT">
+        <hh:heading hh:level="1"/>
+      </hh:paraPr>
+      <hh:paraPr hh:id="1" hh:align="LEFT">
+        <hh:heading hh:level="2"/>
+      </hh:paraPr>
+    </hh:paraProperties>
+    <hh:fontfaces/>
+    <hh:charProperties/>
+    <hh:styles/>
+  </hh:refList>
+</hh:head>`
+    const header = parseHeader(xml)
+    expect(header.paraShapes).toHaveLength(2)
+    expect(header.paraShapes[0]).toEqual({ id: 0, align: 'left', headingLevel: 1 })
+    expect(header.paraShapes[1]).toEqual({ id: 1, align: 'left', headingLevel: 2 })
+  })
+
+  it('parses paraShapes without heading level', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:paraProperties>
+      <hh:paraPr hh:id="0" hh:align="LEFT"/>
+    </hh:paraProperties>
+    <hh:fontfaces/>
+    <hh:charProperties/>
+    <hh:styles/>
+  </hh:refList>
+</hh:head>`
+    const header = parseHeader(xml)
+    expect(header.paraShapes).toHaveLength(1)
+    expect(header.paraShapes[0]).toEqual({ id: 0, align: 'left' })
+    expect(header.paraShapes[0].headingLevel).toBeUndefined()
+  })
+
+  it('parses styles with type attribute', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:styles>
+      <hh:style hh:id="0" hh:name="Normal" hh:charPrIDRef="0" hh:paraPrIDRef="0" hh:type="PARA"/>
+      <hh:style hh:id="1" hh:name="Emphasis" hh:charPrIDRef="1" hh:paraPrIDRef="1" hh:type="CHAR"/>
+    </hh:styles>
+    <hh:fontfaces/>
+    <hh:charProperties/>
+    <hh:paraProperties/>
+  </hh:refList>
+</hh:head>`
+    const header = parseHeader(xml)
+    expect(header.styles).toHaveLength(2)
+    expect(header.styles[0]).toEqual({ id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0, type: 'PARA' })
+    expect(header.styles[1]).toEqual({ id: 1, name: 'Emphasis', charShapeRef: 1, paraShapeRef: 1, type: 'CHAR' })
+  })
+
+  it('parses styles without type attribute', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:styles>
+      <hh:style hh:id="0" hh:name="Normal" hh:charPrIDRef="0" hh:paraPrIDRef="0"/>
+    </hh:styles>
+    <hh:fontfaces/>
+    <hh:charProperties/>
+    <hh:paraProperties/>
+  </hh:refList>
+</hh:head>`
+    const header = parseHeader(xml)
+    expect(header.styles).toHaveLength(1)
+    expect(header.styles[0]).toEqual({ id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0 })
+    expect(header.styles[0].type).toBeUndefined()
+  })
+
   it('handles empty refList', () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">

--- a/src/formats/hwpx/header-parser.ts
+++ b/src/formats/hwpx/header-parser.ts
@@ -54,18 +54,31 @@ export function parseHeader(xml: string): DocumentHeader {
   }))
 
   const rawParaPrs = refList['hh:paraProperties']?.['hh:paraPr'] ?? []
-  const paraShapes: ParaShape[] = rawParaPrs.map((p: Record<string, unknown>) => ({
-    id: p['hh:id'] as number,
-    align: parseAlign(p['hh:align'] as string),
-  }))
+  const paraShapes: ParaShape[] = rawParaPrs.map((p: Record<string, unknown>) => {
+    const shape: ParaShape = {
+      id: p['hh:id'] as number,
+      align: parseAlign(p['hh:align'] as string),
+    }
+    const heading = p['hh:heading'] as Record<string, unknown> | undefined
+    if (heading && heading['hh:level'] !== undefined) {
+      shape.headingLevel = heading['hh:level'] as number
+    }
+    return shape
+  })
 
   const rawStyles = refList['hh:styles']?.['hh:style'] ?? []
-  const styles: Style[] = rawStyles.map((s: Record<string, unknown>) => ({
-    id: s['hh:id'] as number,
-    name: s['hh:name'] as string,
-    charShapeRef: s['hh:charPrIDRef'] as number,
-    paraShapeRef: s['hh:paraPrIDRef'] as number,
-  }))
+  const styles: Style[] = rawStyles.map((s: Record<string, unknown>) => {
+    const style: Style = {
+      id: s['hh:id'] as number,
+      name: s['hh:name'] as string,
+      charShapeRef: s['hh:charPrIDRef'] as number,
+      paraShapeRef: s['hh:paraPrIDRef'] as number,
+    }
+    if (s['hh:type'] !== undefined) {
+      style.type = s['hh:type'] as string
+    }
+    return style
+  })
 
   return { fonts, charShapes, paraShapes, styles }
 }

--- a/src/formats/hwpx/mutator.test.ts
+++ b/src/formats/hwpx/mutator.test.ts
@@ -310,7 +310,7 @@ describe('mutateHwpxZip', () => {
 
       const sectionXml = await zip.file('Contents/section0.xml')!.async('string')
       expect(sectionXml).toContain('Bold Paragraph')
-      expect(sectionXml).toContain('hp:charPrIDRef="1"')
+      expect(sectionXml).toContain('hp:charPrIDRef="8"')
     } finally {
       await unlink(filePath)
     }

--- a/src/formats/hwpx/mutator.test.ts
+++ b/src/formats/hwpx/mutator.test.ts
@@ -480,9 +480,7 @@ describe('mutateHwpxZip', () => {
       const zip = archive.getZip()
 
       await expect(
-        mutateHwpxZip(zip, archive, [
-          { type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 99 },
-        ]),
+        mutateHwpxZip(zip, archive, [{ type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 99 }]),
       ).rejects.toThrow('개요 99')
     } finally {
       await unlink(filePath)

--- a/src/formats/hwpx/mutator.test.ts
+++ b/src/formats/hwpx/mutator.test.ts
@@ -343,6 +343,192 @@ describe('mutateHwpxZip', () => {
     }
   })
 
+  it('addParagraph with heading sets correct styleIDRef and paraPrIDRef', async () => {
+    const filePath = tmpPath('mutator-addParagraph-heading')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await mutateHwpxZip(zip, archive, [
+        { type: 'addParagraph', ref: 's0', text: 'Heading 1', position: 'end', heading: 1 },
+      ])
+
+      const sectionXml = await zip.file('Contents/section0.xml')!.async('string')
+      // 개요 1 style has id=1, charPrIDRef=1, paraPrIDRef=1
+      expect(sectionXml).toContain('Heading 1')
+      expect(sectionXml).toMatch(/hp:styleIDRef="1".*Heading 1|Heading 1.*hp:styleIDRef="1"/s)
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph with heading: 3 sets style/paraPr refs to 3', async () => {
+    const filePath = tmpPath('mutator-addParagraph-heading3')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await mutateHwpxZip(zip, archive, [
+        { type: 'addParagraph', ref: 's0', text: 'Heading 3', position: 'end', heading: 3 },
+      ])
+
+      const sectionXml = await zip.file('Contents/section0.xml')!.async('string')
+      expect(sectionXml).toContain('Heading 3')
+      // The paragraph containing 'Heading 3' should have styleIDRef=3 and paraPrIDRef=3
+      expect(sectionXml).toMatch(/hp:paraPrIDRef="3"[^>]*hp:styleIDRef="3"/)
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph with heading also sets charPrIDRef on run', async () => {
+    const filePath = tmpPath('mutator-addParagraph-heading-charPr')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await mutateHwpxZip(zip, archive, [
+        { type: 'addParagraph', ref: 's0', text: 'Heading 2', position: 'end', heading: 2 },
+      ])
+
+      const sectionXml = await zip.file('Contents/section0.xml')!.async('string')
+      // Run should have charPrIDRef matching the heading's charPrIDRef (2 for heading 2)
+      expect(sectionXml).toMatch(/hp:charPrIDRef="2"[^>]*>\s*<hp:t>Heading 2/s)
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph with style by name sets correct refs', async () => {
+    const filePath = tmpPath('mutator-addParagraph-style-name')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await mutateHwpxZip(zip, archive, [
+        { type: 'addParagraph', ref: 's0', text: 'Styled text', position: 'end', style: '개요 2' },
+      ])
+
+      const sectionXml = await zip.file('Contents/section0.xml')!.async('string')
+      expect(sectionXml).toContain('Styled text')
+      expect(sectionXml).toMatch(/hp:paraPrIDRef="2"[^>]*hp:styleIDRef="2"/)
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph with style by numeric ID sets correct refs', async () => {
+    const filePath = tmpPath('mutator-addParagraph-style-id')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await mutateHwpxZip(zip, archive, [
+        { type: 'addParagraph', ref: 's0', text: 'Style by ID', position: 'end', style: 3 },
+      ])
+
+      const sectionXml = await zip.file('Contents/section0.xml')!.async('string')
+      expect(sectionXml).toContain('Style by ID')
+      // Style id=3 is 개요 3 with charPrIDRef=3, paraPrIDRef=3
+      expect(sectionXml).toMatch(/hp:paraPrIDRef="3"[^>]*hp:styleIDRef="3"/)
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph throws when both heading and style are specified', async () => {
+    const filePath = tmpPath('mutator-addParagraph-both')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await expect(
+        mutateHwpxZip(zip, archive, [
+          { type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 1, style: 'Normal' },
+        ]),
+      ).rejects.toThrow('Cannot specify both heading and style')
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph throws when heading style not found', async () => {
+    const filePath = tmpPath('mutator-addParagraph-heading-missing')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await expect(
+        mutateHwpxZip(zip, archive, [
+          { type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', heading: 99 },
+        ]),
+      ).rejects.toThrow('개요 99')
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph throws when style name not found', async () => {
+    const filePath = tmpPath('mutator-addParagraph-style-missing')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await expect(
+        mutateHwpxZip(zip, archive, [
+          { type: 'addParagraph', ref: 's0', text: 'Bad', position: 'end', style: 'NonExistent' },
+        ]),
+      ).rejects.toThrow('NonExistent')
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
+  it('addParagraph with heading marks headerChanged', async () => {
+    const filePath = tmpPath('mutator-addParagraph-heading-header')
+    const fixture = await createTestHwpx({ paragraphs: ['Body text'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+
+      await mutateHwpxZip(zip, archive, [
+        { type: 'addParagraph', ref: 's0', text: 'Heading', position: 'end', heading: 1 },
+      ])
+
+      // Verify header.xml is still valid (mutator loaded and processed it)
+      const headerXml = await zip.file('Contents/header.xml')!.async('string')
+      expect(headerXml).toContain('hh:head')
+    } finally {
+      await unlink(filePath)
+    }
+  })
+
   it('applies setFormat to inline range with run splitting', async () => {
     const filePath = tmpPath('mutator-inline-split')
     const fixture = await createTestHwpx({ paragraphs: ['HelloWorld'] })

--- a/src/shared/edit-types.ts
+++ b/src/shared/edit-types.ts
@@ -12,6 +12,6 @@ export type EditOperation =
   | { type: 'setFormat'; ref: string; format: FormatOptions; start?: number; end?: number }
   | { type: 'setTableCell'; ref: string; text: string }
   | { type: 'addTable'; ref: string; rows: number; cols: number; data?: string[][] }
-  | { type: 'addParagraph'; ref: string; text: string; position: 'before' | 'after' | 'end'; format?: FormatOptions }
+  | { type: 'addParagraph'; ref: string; text: string; position: 'before' | 'after' | 'end'; format?: FormatOptions; heading?: number; style?: string | number }
 
 export type XmlNode = Record<string, unknown>

--- a/src/shared/edit-types.ts
+++ b/src/shared/edit-types.ts
@@ -12,6 +12,14 @@ export type EditOperation =
   | { type: 'setFormat'; ref: string; format: FormatOptions; start?: number; end?: number }
   | { type: 'setTableCell'; ref: string; text: string }
   | { type: 'addTable'; ref: string; rows: number; cols: number; data?: string[][] }
-  | { type: 'addParagraph'; ref: string; text: string; position: 'before' | 'after' | 'end'; format?: FormatOptions; heading?: number; style?: string | number }
+  | {
+      type: 'addParagraph'
+      ref: string
+      text: string
+      position: 'before' | 'after' | 'end'
+      format?: FormatOptions
+      heading?: number
+      style?: string | number
+    }
 
 export type XmlNode = Record<string, unknown>

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -88,6 +88,32 @@ export async function createTestHwpx(opts: TestHwpxOptions = {}): Promise<Buffer
 </opf:package>`,
   )
 
+  const headingFontSizes = [2200, 1800, 1600, 1400, 1300, 1200, 1100]
+
+  const headingCharPrs = headingFontSizes
+    .map(
+      (size, i) =>
+        `      <hh:charPr hh:id="${i + 1}" hh:height="${size}" hh:fontRef="0"
+        hh:fontBold="1" hh:fontItalic="0" hh:underline="0" hh:color="0"/>`,
+    )
+    .join('\n')
+
+  const headingParaPrs = headingFontSizes
+    .map(
+      (_, i) =>
+        `      <hh:paraPr hh:id="${i + 1}" hh:align="LEFT">
+        <hh:heading hh:type="OUTLINE" hh:idRef="0" hh:level="${i + 1}"/>
+      </hh:paraPr>`,
+    )
+    .join('\n')
+
+  const headingStyles = headingFontSizes
+    .map(
+      (_, i) =>
+        `      <hh:style hh:id="${i + 1}" hh:name="\uAC1C\uC694 ${i + 1}" hh:charPrIDRef="${i + 1}" hh:paraPrIDRef="${i + 1}" hh:type="PARA"/>`,
+    )
+    .join('\n')
+
   zip.file(
     'Contents/header.xml',
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -99,12 +125,15 @@ export async function createTestHwpx(opts: TestHwpxOptions = {}): Promise<Buffer
     <hh:charProperties>
       <hh:charPr hh:id="0" hh:height="${fontHeight}" hh:fontRef="0"
         hh:fontBold="0" hh:fontItalic="0" hh:underline="0" hh:color="0"/>
+${headingCharPrs}
     </hh:charProperties>
     <hh:paraProperties>
       <hh:paraPr hh:id="0" hh:align="JUSTIFY"/>
+${headingParaPrs}
     </hh:paraProperties>
     <hh:styles>
       <hh:style hh:id="0" hh:name="Normal" hh:charPrIDRef="0" hh:paraPrIDRef="0"/>
+${headingStyles}
     </hh:styles>
   </hh:refList>
 </hh:head>`,

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'bun:test'
-import type { DocumentHeader, HwpDocument, Image, Section, Table, TextBox } from './types'
+import type { DocumentHeader, HwpDocument, Image, ParaShape, Section, Style, Table, TextBox } from './types'
 
 describe('types', () => {
   it('HwpDocument type is correct', () => {
@@ -72,6 +72,20 @@ describe('types', () => {
       styles: [{ id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0 }],
     }
     void header
+  })
+
+  it('ParaShape supports optional headingLevel', () => {
+    const body: ParaShape = { id: 0, align: 'left' }
+    const heading: ParaShape = { id: 1, align: 'left', headingLevel: 1 }
+    void body
+    void heading
+  })
+
+  it('Style supports optional type field', () => {
+    const body: Style = { id: 0, name: 'Normal', charShapeRef: 0, paraShapeRef: 0 }
+    const heading: Style = { id: 1, name: '개요 1', charShapeRef: 1, paraShapeRef: 1, type: 'PARA' }
+    void body
+    void heading
   })
 
   it('TextBox type is correct', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type CharShape = {
 export type ParaShape = {
   id: number
   align: 'left' | 'center' | 'right' | 'justify'
+  headingLevel?: number
 }
 
 export type Style = {
@@ -37,6 +38,7 @@ export type Style = {
   name: string
   charShapeRef: number
   paraShapeRef: number
+  type?: string
 }
 
 export type Section = {


### PR DESCRIPTION
## Summary

Add full heading/subtitle paragraph support (개요 1–7) across the entire hwpilot stack. AI agents can now create structured documents with proper heading paragraphs in both HWPX and HWP 5.0 formats.

## Changes

### Type System
- Add `headingLevel` to `ParaShape`, `type` to `Style`, and `heading`/`style` fields to `EditOperation`.

### Parsing (Read Path)
- Parse heading level from `hh:heading` element in HWPX header XML.
- Parse heading level from bits 25–27 of `PARA_SHAPE` record in HWP 5.0 binary.
- Fix HWP `STYLE` record parser to handle non-empty English name field (was using wrong byte offsets, causing misaligned reads).
- Surface `headingLevel` and `styleName` on paragraphs in `read` output.

### Document Creation
- Pre-define 개요 1–7 styles, charShapes (bold, decreasing font sizes), and paraShapes with heading levels in new HWPX documents.
- Pre-define the same 8 styles/charShapes/paraShapes in new HWP 5.0 documents via binary record injection.

### Write Path (Paragraph Add)
- `paragraph add --heading <1-7>` sets heading level by resolving to the matching 개요 style.
- `paragraph add --style <name|id>` sets paragraph style by name ("개요 2") or numeric index (3).
- Validate mutual exclusivity of `--heading` and `--style`, reject `--heading 0` and `--heading 8+`.
- Coerce Commander.js string arguments to integer for numeric style IDs.
- HWPX mutator writes correct `hp:styleIDRef` and `hp:paraPrIDRef` on new paragraph elements.
- HWP mutator writes correct `paraShapeRef` and `styleRef` in binary `PARA_HEADER` records.

### Conversion (HWP → HWPX)
- Preserve heading level and style type during format conversion.
- Fix XML generation for `paraPr` elements with `hh:heading` child (was emitting self-closing tag before child element).

### Daemon
- Forward `heading` and `style` options through the daemon server to mutators.
- Enrich daemon `read` output with heading level and style name, matching direct mode behavior.

## Testing

- 22 new unit/integration test cases across 10 test files.
- 20 new E2E tests covering all formats, all heading levels, style-by-name, style-by-ID, error cases, and cross-format validation (HWP → HWPX conversion roundtrip).
- All 595 unit tests and 213 E2E tests pass.