### PR TITLE
fix(hwp): read correct charShapeRef from PARA_CHAR_SHAPE records

### DIFF
--- a/src/formats/hwp/reader.test.ts
+++ b/src/formats/hwp/reader.test.ts
@@ -456,9 +456,7 @@ describe('PARA_CHAR_SHAPE reading', () => {
     const filePath = '/tmp/test-hwp-charshape-ordering.hwp'
     TMP_FILES.push(filePath)
 
-    const sectionRecords = Buffer.concat([
-      paragraphWithCharShape(0, 'Hello', [{ pos: 0, ref: 5 }]),
-    ])
+    const sectionRecords = Buffer.concat([paragraphWithCharShape(0, 'Hello', [{ pos: 0, ref: 5 }])])
 
     const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
     await Bun.write(filePath, buffer)
@@ -477,7 +475,7 @@ describe('PARA_CHAR_SHAPE reading', () => {
     const sectionRecords = Buffer.concat([
       buildRecord(TAG.PARA_HEADER, 0, Buffer.alloc(0)),
       buildRecord(TAG.PARA_CHAR_SHAPE, 1, paraCharShapeData({ pos: 0, ref: 3 })),
-      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([...('World')].map((ch) => ch.charCodeAt(0)).concat(0x0000))),
+      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([...'World'].map((ch) => ch.charCodeAt(0)).concat(0x0000))),
     ])
 
     const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
@@ -518,9 +516,7 @@ describe('PARA_CHAR_SHAPE reading', () => {
     const filePath = '/tmp/test-hwp-charshape-large-ref.hwp'
     TMP_FILES.push(filePath)
 
-    const sectionRecords = Buffer.concat([
-      paragraphWithCharShape(0, 'Test', [{ pos: 0, ref: 70000 }]),
-    ])
+    const sectionRecords = Buffer.concat([paragraphWithCharShape(0, 'Test', [{ pos: 0, ref: 70000 }])])
 
     const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
     await Bun.write(filePath, buffer)

--- a/src/formats/hwp/reader.test.ts
+++ b/src/formats/hwp/reader.test.ts
@@ -429,6 +429,124 @@ describe('loadHwp', () => {
   })
 })
 
+describe('PARA_CHAR_SHAPE reading', () => {
+  function paraCharShapeData(...entries: Array<{ pos: number; ref: number }>): Buffer {
+    const buf = Buffer.alloc(entries.length * 8)
+    for (let i = 0; i < entries.length; i++) {
+      buf.writeUInt32LE(entries[i].pos, i * 8)
+      buf.writeUInt32LE(entries[i].ref, i * 8 + 4)
+    }
+    return buf
+  }
+
+  function paragraphWithCharShape(
+    level: number,
+    text: string,
+    charShapeEntries: Array<{ pos: number; ref: number }>,
+  ): Buffer {
+    // Real HWP record order: PARA_HEADER, PARA_TEXT, PARA_CHAR_SHAPE, PARA_LINE_SEG
+    return Buffer.concat([
+      buildRecord(TAG.PARA_HEADER, level, Buffer.alloc(0)),
+      buildRecord(TAG.PARA_TEXT, level + 1, encodeUint16([...text].map((ch) => ch.charCodeAt(0)).concat(0x0000))),
+      buildRecord(TAG.PARA_CHAR_SHAPE, level + 1, paraCharShapeData(...charShapeEntries)),
+    ])
+  }
+
+  it('reads charShapeRef when PARA_TEXT appears before PARA_CHAR_SHAPE', async () => {
+    const filePath = '/tmp/test-hwp-charshape-ordering.hwp'
+    TMP_FILES.push(filePath)
+
+    const sectionRecords = Buffer.concat([
+      paragraphWithCharShape(0, 'Hello', [{ pos: 0, ref: 5 }]),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const run = doc.sections[0].paragraphs[0].runs[0]
+
+    expect(run.charShapeRef).toBe(5)
+  })
+
+  it('reads charShapeRef when PARA_CHAR_SHAPE appears before PARA_TEXT', async () => {
+    const filePath = '/tmp/test-hwp-charshape-before-text.hwp'
+    TMP_FILES.push(filePath)
+
+    // Reversed order: PARA_HEADER, PARA_CHAR_SHAPE, PARA_TEXT
+    const sectionRecords = Buffer.concat([
+      buildRecord(TAG.PARA_HEADER, 0, Buffer.alloc(0)),
+      buildRecord(TAG.PARA_CHAR_SHAPE, 1, paraCharShapeData({ pos: 0, ref: 3 })),
+      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([...('World')].map((ch) => ch.charCodeAt(0)).concat(0x0000))),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const run = doc.sections[0].paragraphs[0].runs[0]
+
+    expect(run.charShapeRef).toBe(3)
+  })
+
+  it('splits text into multiple runs for inline formatting', async () => {
+    const filePath = '/tmp/test-hwp-charshape-inline.hwp'
+    TMP_FILES.push(filePath)
+
+    // 'Hello World' with two charShape entries: pos 0 ref 1, pos 5 ref 2
+    const sectionRecords = Buffer.concat([
+      paragraphWithCharShape(0, 'Hello World', [
+        { pos: 0, ref: 1 },
+        { pos: 5, ref: 2 },
+      ]),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const runs = doc.sections[0].paragraphs[0].runs
+
+    expect(runs).toHaveLength(2)
+    expect(runs[0].text).toBe('Hello')
+    expect(runs[0].charShapeRef).toBe(1)
+    expect(runs[1].text).toBe(' World')
+    expect(runs[1].charShapeRef).toBe(2)
+  })
+
+  it('handles large charShapeRef values exceeding uint16 range', async () => {
+    const filePath = '/tmp/test-hwp-charshape-large-ref.hwp'
+    TMP_FILES.push(filePath)
+
+    const sectionRecords = Buffer.concat([
+      paragraphWithCharShape(0, 'Test', [{ pos: 0, ref: 70000 }]),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const run = doc.sections[0].paragraphs[0].runs[0]
+
+    expect(run.charShapeRef).toBe(70000)
+  })
+
+  it('defaults to charShapeRef 0 when no PARA_CHAR_SHAPE record exists', async () => {
+    const filePath = '/tmp/test-hwp-charshape-missing.hwp'
+    TMP_FILES.push(filePath)
+
+    const sectionRecords = paragraphRecord(0, 'No charshape')
+
+    const buffer = createHwpCfbBufferWithRecords(0, Buffer.alloc(0), sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const run = doc.sections[0].paragraphs[0].runs[0]
+
+    expect(run.charShapeRef).toBe(0)
+  })
+})
+
 describe('extractParaText', () => {
   it('extracts UTF-16LE text and skips inline control payload', () => {
     const data = encodeUint16([

--- a/src/formats/hwp/reader.ts
+++ b/src/formats/hwp/reader.ts
@@ -276,6 +276,7 @@ function parseSection(buffer: Buffer, sectionIndex: number, binDataById: Map<num
     {
       runs: Run[]
       charShapeRef: number
+      charShapeEntries: Array<{ pos: number; ref: number }> | null
       paraShapeRef: number
       styleRef: number
       target: 'section' | 'cell' | 'textBox'
@@ -365,6 +366,7 @@ function parseSection(buffer: Buffer, sectionIndex: number, binDataById: Map<num
   ): {
     runs: Run[]
     charShapeRef: number
+    charShapeEntries: Array<{ pos: number; ref: number }> | null
     paraShapeRef: number
     styleRef: number
     target: 'section' | 'cell' | 'textBox'
@@ -402,6 +404,7 @@ function parseSection(buffer: Buffer, sectionIndex: number, binDataById: Map<num
       activeParagraphs.set(header.level, {
         runs: [],
         charShapeRef: 0,
+        charShapeEntries: null,
         paraShapeRef,
         styleRef,
         target,
@@ -415,8 +418,33 @@ function parseSection(buffer: Buffer, sectionIndex: number, binDataById: Map<num
         continue
       }
 
-      if (data.length >= 6) {
-        paragraph.charShapeRef = data.readUInt16LE(4)
+      // Parse all (pos: uint32, ref: uint32) entries
+      const entries: Array<{ pos: number; ref: number }> = []
+      if (data.length >= 8 && data.length % 8 === 0) {
+        for (let i = 0; i < data.length; i += 8) {
+          entries.push({ pos: data.readUInt32LE(i), ref: data.readUInt32LE(i + 4) })
+        }
+      } else if (data.length >= 6) {
+        // Legacy short format: 6 bytes with charShapeRef as uint16 at offset 4
+        entries.push({ pos: data.readUInt16LE(0), ref: data.readUInt16LE(4) })
+      }
+
+      if (entries.length > 0) {
+        paragraph.charShapeRef = entries[0].ref
+        paragraph.charShapeEntries = entries
+      }
+
+      // Retroactively update runs if PARA_TEXT was already processed
+      if (paragraph.runs.length > 0) {
+        if (entries.length <= 1) {
+          for (const run of paragraph.runs) {
+            run.charShapeRef = paragraph.charShapeRef
+          }
+        } else {
+          // Multiple entries — split the single run into multiple runs by char position
+          const fullText = paragraph.runs.map((r) => r.text).join('')
+          paragraph.runs = splitTextByCharShapeEntries(fullText, entries)
+        }
       }
       continue
     }
@@ -429,7 +457,14 @@ function parseSection(buffer: Buffer, sectionIndex: number, binDataById: Map<num
 
       const text = extractParaText(data)
       if (text) {
-        paragraph.runs.push({ text, charShapeRef: paragraph.charShapeRef })
+        if (paragraph.charShapeEntries && paragraph.charShapeEntries.length > 1) {
+          // PARA_CHAR_SHAPE was already processed with multiple entries
+          for (const run of splitTextByCharShapeEntries(text, paragraph.charShapeEntries)) {
+            paragraph.runs.push(run)
+          }
+        } else {
+          paragraph.runs.push({ text, charShapeRef: paragraph.charShapeRef })
+        }
       }
       continue
     }
@@ -689,4 +724,20 @@ export function extractParaText(data: Buffer): string {
   }
 
   return chars.join('')
+}
+
+function splitTextByCharShapeEntries(
+  text: string,
+  entries: Array<{ pos: number; ref: number }>,
+): Run[] {
+  const runs: Run[] = []
+  for (let i = 0; i < entries.length; i++) {
+    const start = entries[i].pos
+    const end = i + 1 < entries.length ? entries[i + 1].pos : text.length
+    const slice = text.substring(start, end)
+    if (slice) {
+      runs.push({ text: slice, charShapeRef: entries[i].ref })
+    }
+  }
+  return runs.length > 0 ? runs : [{ text, charShapeRef: entries[0]?.ref ?? 0 }]
 }

--- a/src/formats/hwp/reader.ts
+++ b/src/formats/hwp/reader.ts
@@ -726,10 +726,7 @@ export function extractParaText(data: Buffer): string {
   return chars.join('')
 }
 
-function splitTextByCharShapeEntries(
-  text: string,
-  entries: Array<{ pos: number; ref: number }>,
-): Run[] {
+function splitTextByCharShapeEntries(text: string, entries: Array<{ pos: number; ref: number }>): Run[] {
   const runs: Run[] = []
   for (let i = 0; i < entries.length; i++) {
     const start = entries[i].pos


### PR DESCRIPTION
## Summary

Fix the HWP binary reader always returning `charShapeRef=0` for paragraph runs. The writer was correct — the bug was in the reader.

## Problem

In HWP 5.0 binary format, section records appear in this order:

```
PARA_HEADER → PARA_TEXT → PARA_CHAR_SHAPE → PARA_LINE_SEG
```

The reader processed records sequentially, creating runs at `PARA_TEXT` time with `paragraph.charShapeRef` (still `0` from initialization). By the time `PARA_CHAR_SHAPE` was parsed with the correct value, the runs were already stamped with `0`.

This made `edit format`, `paragraph add --bold`, and all HWP character formatting appear broken — the commands wrote correctly to disk, but reads always reported the default style.

## Changes

### Reader fix (`src/formats/hwp/reader.ts`)
- **Record ordering**: When `PARA_CHAR_SHAPE` arrives after `PARA_TEXT`, retroactively update existing runs with the correct charShapeRef. Also handles the reverse order.
- **UInt16 → UInt32**: Fix `readUInt16LE(4)` → `readUInt32LE(4)` for standard 8-byte `(pos, ref)` entries. Supports charShapeRef values >65535.
- **Inline formatting**: Parse all `(pos, ref)` entries from `PARA_CHAR_SHAPE`. When multiple entries exist, split text into separate runs with per-range charShapeRefs. Enables correct read-back of `edit format --bold --start N --end M`.

### Tests (`src/formats/hwp/reader.test.ts`)
- `PARA_TEXT` before `PARA_CHAR_SHAPE` (the real-world bug case).
- `PARA_CHAR_SHAPE` before `PARA_TEXT` (reverse ordering).
- Multiple `(pos, ref)` entries splitting text into runs.
- Large charShapeRef values exceeding uint16 range.
- Missing `PARA_CHAR_SHAPE` defaults to `0`.

## Testing

- All 600 unit tests pass, 0 failures.
- Typecheck clean.
- E2E verified: `create` → `edit format --bold --size 22` → `read` returns `charShapeRef=8`, `bold=true`, `fontSize=22`.
- E2E verified: `paragraph add --bold --size 16` → reads back correctly.
- E2E verified: `edit format --bold --start 0 --end 5` on "Hello World" → two runs: "Hello" (bold), " World" (normal).