### PR TITLE
feat(table): add positional insertion to table add

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -28,10 +28,10 @@ hwpilot edit text document.hwpx s0.p0 "New content"
 hwpilot table edit document.hwpx s0.t0.r0.c0 "Cell value"
 
 # Add a 3×4 table
-hwpilot table add document.hwpx 3 4
+hwpilot table add document.hwpx s0 3 4
 
 # Add a table with data
-hwpilot table add document.hwpx 2 2 --data '[["A","B"],["C","D"]]'
+hwpilot table add document.hwpx s0 2 2 --data '[["A","B"],["C","D"]]'
 
 # Bold + resize
 hwpilot edit format document.hwpx s0.p0 --bold --size 16
@@ -176,12 +176,13 @@ hwpilot table edit report.hwpx s0.t0.r0.c1 "Date"
 Add a new table to the document.
 
 ```bash
-hwpilot table add <file> <rows> <cols> [--data <json>] [--pretty]
+hwpilot table add <file> <ref> <rows> <cols> [--position before|after|end] [--data <json>] [--pretty]
 ```
 
 ```bash
-hwpilot table add report.hwpx 3 4
-hwpilot table add report.hwpx 2 2 --data '[["Name","Date"],["Alice","2025-01-01"]]'
+hwpilot table add report.hwpx s0 3 4
+hwpilot table add report.hwpx s0 2 2 --data '[["Name","Date"],["Alice","2025-01-01"]]'
+hwpilot table add report.hwpx s0.p2 3 4 --position after  # Insert table after paragraph 2
 ```
 ### table list
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ hwpilot read document.hwpx --limit 20              # 문서 읽기
 hwpilot find document.hwpx "청구취지"                # 텍스트 검색
 hwpilot edit text document.hwpx s0.p0 "새 내용"     # 문단 편집
 hwpilot table edit document.hwpx s0.t0.r0.c0 "값"   # 표 셀 편집
-hwpilot table add document.hwpx 3 4                 # 3×4 표 추가
-hwpilot table add document.hwpx 2 2 --data '[["A","B"],["C","D"]]'  # 데이터와 함께 표 추가
+hwpilot table add document.hwpx s0 3 4                 # 3×4 표 추가
+hwpilot table add document.hwpx s0 2 2 --data '[["A","B"],["C","D"]]'  # 데이터와 함께 표 추가
+hwpilot table add document.hwpx s0.p2 3 4 --position after  # 특정 위치에 표 삽입
 hwpilot edit format document.hwpx s0.p0 --bold --size 16  # 서식 변경
 hwpilot edit format document.hwpx s0.p0 --bold --start 0 --end 5  # 인라인 서식
 hwpilot paragraph add document.hwpx s0 "새 문단" --position end  # 문단 추가

--- a/e2e/table-add.test.ts
+++ b/e2e/table-add.test.ts
@@ -31,7 +31,7 @@ describe('Table Add — HWP fixture', () => {
       const beforeCount = beforeTables.length
 
       // when — add a 2x3 table
-      const addResult = await runCli(['table', 'add', temp, '2', '3'])
+      const addResult = await runCli(['table', 'add', temp, 's0', '2', '3'])
       const addOutput = parseOutput(addResult) as any
       expect(addOutput.success).toBe(true)
       expect(addOutput.rows).toBe(2)
@@ -55,7 +55,7 @@ describe('Table Add — HWP fixture', () => {
       const expectedRef = `s0.t${beforeTables.length}`
 
       // when
-      const addResult = await runCli(['table', 'add', temp, '1', '2'])
+      const addResult = await runCli(['table', 'add', temp, 's0', '1', '2'])
       const addOutput = parseOutput(addResult) as any
 
       // then
@@ -74,7 +74,7 @@ describe('Table Add — HWP fixture', () => {
       ]
 
       // when — add with data
-      const addResult = await runCli(['table', 'add', temp, '2', '3', '--data', JSON.stringify(data)])
+      const addResult = await runCli(['table', 'add', temp, 's0', '2', '3', '--data', JSON.stringify(data)])
       const addOutput = parseOutput(addResult) as any
       expect(addOutput.success).toBe(true)
       const newRef = addOutput.ref
@@ -97,7 +97,7 @@ describe('Table Add — HWP fixture', () => {
       const temp = await tempCopy(FIXTURE)
       tempFiles.push(temp)
 
-      const addResult = await runCli(['table', 'add', temp, '2', '2'])
+      const addResult = await runCli(['table', 'add', temp, 's0', '2', '2'])
       const addOutput = parseOutput(addResult) as any
       const newRef = addOutput.ref
 
@@ -123,7 +123,7 @@ describe('Table Add — HWP fixture', () => {
       parseOutput(beforeText) // ensure it parses without error
 
       // when
-      await runCli(['table', 'add', temp, '2', '2', '--data', '[["X","Y"],["1","2"]]'])
+      await runCli(['table', 'add', temp, 's0', '2', '2', '--data', '[["X","Y"],["1","2"]]'])
 
       // then — original text still present
       const afterText = await runCli(['text', temp])
@@ -145,7 +145,7 @@ describe('Table Add — HWP fixture', () => {
       const originalCell = beforeTable.rows[0].cells[0].text
 
       // when
-      await runCli(['table', 'add', temp, '1', '1', '--data', '[["NEW"]]'])
+      await runCli(['table', 'add', temp, 's0', '1', '1', '--data', '[["NEW"]]'])
 
       // then — existing table unchanged
       const afterResult = await runCli(['table', 'read', temp, 's0.t0'])
@@ -160,7 +160,7 @@ describe('Table Add — HWP fixture', () => {
       tempFiles.push(temp)
 
       const marker = 'TABLE_ADD_CV_2026'
-      await runCli(['table', 'add', temp, '1', '2', '--data', JSON.stringify([[marker, 'test']])])
+      await runCli(['table', 'add', temp, 's0', '1', '2', '--data', JSON.stringify([[marker, 'test']])])
 
       await validateFile(temp)
       const found = await crossValidate(temp, marker)
@@ -178,7 +178,7 @@ describe('Table Add — HWPX (created document)', () => {
     expect((parseOutput(createResult) as any).success).toBe(true)
 
     // when — add a table
-    const addResult = await runCli(['table', 'add', hwpxFile, '2', '3', '--data', '[["A","B","C"],["D","E","F"]]'])
+    const addResult = await runCli(['table', 'add', hwpxFile, 's0', '2', '3', '--data', '[["A","B","C"],["D","E","F"]]'])
     const addOutput = parseOutput(addResult) as any
     expect(addOutput.success).toBe(true)
     expect(addOutput.ref).toBe('s0.t0')
@@ -196,7 +196,7 @@ describe('Table Add — HWPX (created document)', () => {
     await runCli(['create', hwpxFile])
 
     const marker = 'HWPX_TABLE_ADD_2026'
-    await runCli(['table', 'add', hwpxFile, '1', '1', '--data', JSON.stringify([[marker]])])
+    await runCli(['table', 'add', hwpxFile, 's0', '1', '1', '--data', JSON.stringify([[marker]])])
 
     // directly inspect the HWPX zip XML
     const data = await readFile(hwpxFile)
@@ -208,11 +208,129 @@ describe('Table Add — HWPX (created document)', () => {
   })
 })
 
+describe('E. Positional Table Add', () => {
+  describe('HWPX position tests', () => {
+    it('adds table before first paragraph in HWPX', async () => {
+      const hwpxFile = tempPath('hwpx-pos-before', '.hwpx')
+
+      // given — create HWPX with named paragraphs
+      await runCli(['create', hwpxFile])
+      await runCli(['edit', 'text', hwpxFile, 's0.p0', 'Paragraph Zero'])
+      await runCli(['paragraph', 'add', hwpxFile, 's0', 'Paragraph One', '--position', 'end'])
+
+      // when — add table before first paragraph
+      const addResult = await runCli([
+        'table', 'add', hwpxFile, 's0.p0', '1', '2',
+        '--position', 'before',
+        '--data', '[["TBL_BEFORE_A","TBL_BEFORE_B"]]',
+      ])
+      expect((parseOutput(addResult) as any).success).toBe(true)
+
+      // then — table marker appears before paragraph text in raw XML
+      const data = await readFile(hwpxFile)
+      const zip = await JSZip.loadAsync(data)
+      const xml = (await zip.file('Contents/section0.xml')?.async('string'))!
+      expect(xml).toContain('TBL_BEFORE_A')
+      expect(xml).toContain('Paragraph Zero')
+      const tblMarkerPos = xml.indexOf('TBL_BEFORE_A')
+      const paraZeroPos = xml.indexOf('Paragraph Zero')
+      expect(tblMarkerPos).toBeLessThan(paraZeroPos)
+    })
+
+    it('adds table after first paragraph in HWPX', async () => {
+      const hwpxFile = tempPath('hwpx-pos-after', '.hwpx')
+
+      // given — create HWPX with named paragraphs
+      await runCli(['create', hwpxFile])
+      await runCli(['edit', 'text', hwpxFile, 's0.p0', 'Paragraph Zero'])
+      await runCli(['paragraph', 'add', hwpxFile, 's0', 'Paragraph One', '--position', 'end'])
+
+      // when — add table after first paragraph
+      const addResult = await runCli([
+        'table', 'add', hwpxFile, 's0.p0', '1', '2',
+        '--position', 'after',
+        '--data', '[["TBL_AFTER_A","TBL_AFTER_B"]]',
+      ])
+      expect((parseOutput(addResult) as any).success).toBe(true)
+
+      // then — table marker appears after Paragraph Zero but before Paragraph One
+      const data = await readFile(hwpxFile)
+      const zip = await JSZip.loadAsync(data)
+      const xml = (await zip.file('Contents/section0.xml')?.async('string'))!
+      expect(xml).toContain('TBL_AFTER_A')
+      const paraZeroPos = xml.indexOf('Paragraph Zero')
+      const tblMarkerPos = xml.indexOf('TBL_AFTER_A')
+      const paraOnePos = xml.indexOf('Paragraph One')
+      expect(paraZeroPos).toBeLessThan(tblMarkerPos)
+      expect(tblMarkerPos).toBeLessThan(paraOnePos)
+    })
+  })
+
+  describe('HWP position tests', () => {
+    it('adds table before first paragraph in HWP', async () => {
+      const temp = await tempCopy(FIXTURE)
+      tempFiles.push(temp)
+
+      // when — add table before first paragraph
+      const addResult = await runCli([
+        'table', 'add', temp, 's0.p0', '1', '2',
+        '--position', 'before',
+        '--data', '[["HWP_BEFORE_A","HWP_BEFORE_B"]]',
+      ])
+      expect((parseOutput(addResult) as any).success).toBe(true)
+
+      // then — file validates and data survives cross-validation
+      await validateFile(temp)
+      const found = await crossValidate(temp, 'HWP_BEFORE_A')
+      expect(found).toBe(true)
+    })
+
+    it('adds table after first paragraph in HWP', async () => {
+      const temp = await tempCopy(FIXTURE)
+      tempFiles.push(temp)
+
+      // when — add table after first paragraph
+      const addResult = await runCli([
+        'table', 'add', temp, 's0.p0', '1', '2',
+        '--position', 'after',
+        '--data', '[["HWP_AFTER_A","HWP_AFTER_B"]]',
+      ])
+      expect((parseOutput(addResult) as any).success).toBe(true)
+
+      // then — file validates and data survives cross-validation
+      await validateFile(temp)
+      const found = await crossValidate(temp, 'HWP_AFTER_A')
+      expect(found).toBe(true)
+    })
+  })
+
+  describe('Cross-validation', () => {
+    it('HWP positioned table data survives HWP→HWPX conversion', async () => {
+      const temp = await tempCopy(FIXTURE)
+      tempFiles.push(temp)
+
+      const marker = 'POSITIONED_TABLE_CV_2026'
+
+      // when — add table at specific position in HWP
+      await runCli([
+        'table', 'add', temp, 's0.p0', '1', '2',
+        '--position', 'before',
+        '--data', JSON.stringify([[marker, 'cross-val']]),
+      ])
+
+      // then — marker survives HWP→HWPX conversion
+      await validateFile(temp)
+      const found = await crossValidate(temp, marker)
+      expect(found).toBe(true)
+    })
+  })
+})
+
 describe('Z. Validation', () => {
   it('HWP with added table passes validation', async () => {
     const temp = await tempCopy(FIXTURE)
     tempFiles.push(temp)
-    await runCli(['table', 'add', temp, '2', '2', '--data', '[["v1","v2"],["v3","v4"]]'])
+    await runCli(['table', 'add', temp, 's0', '2', '2', '--data', '[["v1","v2"],["v3","v4"]]'])
     await validateFile(temp)
   })
 })

--- a/e2e/table-add.test.ts
+++ b/e2e/table-add.test.ts
@@ -178,7 +178,16 @@ describe('Table Add — HWPX (created document)', () => {
     expect((parseOutput(createResult) as any).success).toBe(true)
 
     // when — add a table
-    const addResult = await runCli(['table', 'add', hwpxFile, 's0', '2', '3', '--data', '[["A","B","C"],["D","E","F"]]'])
+    const addResult = await runCli([
+      'table',
+      'add',
+      hwpxFile,
+      's0',
+      '2',
+      '3',
+      '--data',
+      '[["A","B","C"],["D","E","F"]]',
+    ])
     const addOutput = parseOutput(addResult) as any
     expect(addOutput.success).toBe(true)
     expect(addOutput.ref).toBe('s0.t0')
@@ -220,9 +229,16 @@ describe('E. Positional Table Add', () => {
 
       // when — add table before first paragraph
       const addResult = await runCli([
-        'table', 'add', hwpxFile, 's0.p0', '1', '2',
-        '--position', 'before',
-        '--data', '[["TBL_BEFORE_A","TBL_BEFORE_B"]]',
+        'table',
+        'add',
+        hwpxFile,
+        's0.p0',
+        '1',
+        '2',
+        '--position',
+        'before',
+        '--data',
+        '[["TBL_BEFORE_A","TBL_BEFORE_B"]]',
       ])
       expect((parseOutput(addResult) as any).success).toBe(true)
 
@@ -247,9 +263,16 @@ describe('E. Positional Table Add', () => {
 
       // when — add table after first paragraph
       const addResult = await runCli([
-        'table', 'add', hwpxFile, 's0.p0', '1', '2',
-        '--position', 'after',
-        '--data', '[["TBL_AFTER_A","TBL_AFTER_B"]]',
+        'table',
+        'add',
+        hwpxFile,
+        's0.p0',
+        '1',
+        '2',
+        '--position',
+        'after',
+        '--data',
+        '[["TBL_AFTER_A","TBL_AFTER_B"]]',
       ])
       expect((parseOutput(addResult) as any).success).toBe(true)
 
@@ -273,9 +296,16 @@ describe('E. Positional Table Add', () => {
 
       // when — add table before first paragraph
       const addResult = await runCli([
-        'table', 'add', temp, 's0.p0', '1', '2',
-        '--position', 'before',
-        '--data', '[["HWP_BEFORE_A","HWP_BEFORE_B"]]',
+        'table',
+        'add',
+        temp,
+        's0.p0',
+        '1',
+        '2',
+        '--position',
+        'before',
+        '--data',
+        '[["HWP_BEFORE_A","HWP_BEFORE_B"]]',
       ])
       expect((parseOutput(addResult) as any).success).toBe(true)
 
@@ -291,9 +321,16 @@ describe('E. Positional Table Add', () => {
 
       // when — add table after first paragraph
       const addResult = await runCli([
-        'table', 'add', temp, 's0.p0', '1', '2',
-        '--position', 'after',
-        '--data', '[["HWP_AFTER_A","HWP_AFTER_B"]]',
+        'table',
+        'add',
+        temp,
+        's0.p0',
+        '1',
+        '2',
+        '--position',
+        'after',
+        '--data',
+        '[["HWP_AFTER_A","HWP_AFTER_B"]]',
       ])
       expect((parseOutput(addResult) as any).success).toBe(true)
 
@@ -313,9 +350,16 @@ describe('E. Positional Table Add', () => {
 
       // when — add table at specific position in HWP
       await runCli([
-        'table', 'add', temp, 's0.p0', '1', '2',
-        '--position', 'before',
-        '--data', JSON.stringify([[marker, 'cross-val']]),
+        'table',
+        'add',
+        temp,
+        's0.p0',
+        '1',
+        '2',
+        '--position',
+        'before',
+        '--data',
+        JSON.stringify([[marker, 'cross-val']]),
       ])
 
       // then — marker survives HWP→HWPX conversion

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,14 +131,15 @@ tableCmd
     await tableListCommand(file, options)
   })
 
-// hwpilot table add <file> <rows> <cols>
+// hwpilot table add <file> <ref> <rows> <cols>
 tableCmd
-  .command('add <file> <rows> <cols>')
+  .command('add <file> <ref> <rows> <cols>')
   .description('Add a new table to the document')
+  .option('--position <pos>', 'Insertion position: before|after|end', 'end')
   .option('--data <json>', 'Cell data as JSON array of arrays')
   .option('--pretty', 'Pretty-print JSON output')
-  .action(async (file: string, rows: string, cols: string, options: { data?: string; pretty?: boolean }) => {
-    await tableAddCommand(file, Number(rows), Number(cols), options)
+  .action(async (file: string, ref: string, rows: string, cols: string, options: { position?: string; data?: string; pretty?: boolean }) => {
+    await tableAddCommand(file, ref, Number(rows), Number(cols), options)
   })
 
 // hwpilot paragraph

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,9 +138,17 @@ tableCmd
   .option('--position <pos>', 'Insertion position: before|after|end', 'end')
   .option('--data <json>', 'Cell data as JSON array of arrays')
   .option('--pretty', 'Pretty-print JSON output')
-  .action(async (file: string, ref: string, rows: string, cols: string, options: { position?: string; data?: string; pretty?: boolean }) => {
-    await tableAddCommand(file, ref, Number(rows), Number(cols), options)
-  })
+  .action(
+    async (
+      file: string,
+      ref: string,
+      rows: string,
+      cols: string,
+      options: { position?: string; data?: string; pretty?: boolean },
+    ) => {
+      await tableAddCommand(file, ref, Number(rows), Number(cols), options)
+    },
+  )
 
 // hwpilot paragraph
 const paragraphCmd = program.command('paragraph').description('Paragraph operations')

--- a/src/commands/table.test.ts
+++ b/src/commands/table.test.ts
@@ -256,7 +256,7 @@ describe('tableAddCommand', () => {
     await Bun.write(TEST_FILE, buffer)
 
     captureOutput()
-    await tableAddCommand(TEST_FILE, 2, 3, {})
+    await tableAddCommand(TEST_FILE, 's0', 2, 3, {})
     restoreOutput()
 
     const output = JSON.parse(logs[0])
@@ -279,7 +279,7 @@ describe('tableAddCommand', () => {
     await Bun.write(TEST_FILE, buffer)
 
     captureOutput()
-    await tableAddCommand(TEST_FILE, 2, 2, { data: '[["A","B"],["C","D"]]' })
+    await tableAddCommand(TEST_FILE, 's0', 2, 2, { data: '[["A","B"],["C","D"]]' })
     restoreOutput()
 
     const output = JSON.parse(logs[0])
@@ -304,7 +304,7 @@ describe('tableAddCommand', () => {
     await Bun.write(TEST_FILE, buffer)
 
     captureOutput()
-    await tableAddCommand(TEST_FILE, 1, 2, { data: '[["New1","New2"]]' })
+    await tableAddCommand(TEST_FILE, 's0', 1, 2, { data: '[["New1","New2"]]' })
     restoreOutput()
 
     const output = JSON.parse(logs[0])
@@ -323,7 +323,7 @@ describe('tableAddCommand', () => {
     await Bun.write(TEST_HWP_FILE, hwpBuffer)
 
     captureOutput()
-    await tableAddCommand(TEST_HWP_FILE, 2, 2, { data: '[["A","B"],["C","D"]]' })
+    await tableAddCommand(TEST_HWP_FILE, 's0', 2, 2, { data: '[["A","B"],["C","D"]]' })
     restoreOutput()
 
     const output = JSON.parse(logs[0])

--- a/src/commands/table.ts
+++ b/src/commands/table.ts
@@ -149,9 +149,7 @@ export async function tableAddCommand(
     const parsedRef = parseRef(ref)
 
     if ((position === 'before' || position === 'after') && parsedRef.paragraph === undefined) {
-      throw new Error(
-        `table add with position '${position}' requires a paragraph reference (e.g., s0.p0)`,
-      )
+      throw new Error(`table add with position '${position}' requires a paragraph reference (e.g., s0.p0)`)
     }
 
     const data: string[][] | undefined = options.data ? JSON.parse(options.data) : undefined

--- a/src/commands/table.ts
+++ b/src/commands/table.ts
@@ -130,11 +130,30 @@ export async function tableEditCommand(
 
 export async function tableAddCommand(
   file: string,
+  ref: string,
   rows: number,
   cols: number,
-  options: { data?: string; pretty?: boolean },
+  options: { position?: string; data?: string; pretty?: boolean },
 ): Promise<void> {
   try {
+    const position = (options.position ?? 'end') as 'before' | 'after' | 'end'
+
+    if (!['before', 'after', 'end'].includes(position)) {
+      throw new Error(`Invalid position: ${position}. Must be 'before', 'after', or 'end'`)
+    }
+
+    if (!validateRef(ref)) {
+      throw new Error(`Invalid reference: ${ref}`)
+    }
+
+    const parsedRef = parseRef(ref)
+
+    if ((position === 'before' || position === 'after') && parsedRef.paragraph === undefined) {
+      throw new Error(
+        `table add with position '${position}' requires a paragraph reference (e.g., s0.p0)`,
+      )
+    }
+
     const data: string[][] | undefined = options.data ? JSON.parse(options.data) : undefined
 
     if (data) {
@@ -143,7 +162,7 @@ export async function tableAddCommand(
       }
     }
 
-    const daemonResult = await dispatchViaDaemon(file, 'table-add', { rows, cols, data })
+    const daemonResult = await dispatchViaDaemon(file, 'table-add', { ref, rows, cols, data, position })
     if (daemonResult !== null) {
       if (!daemonResult.success) {
         const errorOptions =
@@ -161,21 +180,21 @@ export async function tableAddCommand(
     }
 
     const format = await detectFormat(file)
-    const ref = 's0'
 
     const sections = format === 'hwp' ? (await loadHwp(file)).sections : await loadHwpxSections(file)
-    const tableCount = sections[0]?.tables.length ?? 0
+    const tableCount = sections[parsedRef.section]?.tables.length ?? 0
 
     if (format === 'hwp') {
-      await editHwp(file, [{ type: 'addTable', ref, rows, cols, data }])
+      await editHwp(file, [{ type: 'addTable', ref, rows, cols, data, position }])
     } else {
-      await editHwpx(file, [{ type: 'addTable', ref, rows, cols, data }])
+      await editHwpx(file, [{ type: 'addTable', ref, rows, cols, data, position }])
     }
 
-    const newRef = buildRef({ section: 0, table: tableCount })
+    const newRef = buildRef({ section: parsedRef.section, table: tableCount })
     console.log(formatOutput({ ref: newRef, rows, cols, success: true }, options.pretty))
   } catch (e) {
-    handleError(e, { context: { file } })
+    const hint = await getRefHint(file, ref).catch(() => undefined)
+    handleError(e, { context: { ref, file }, hint })
   }
 }
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -274,7 +274,10 @@ async function handleRequest(
         const rows = numberArg(msg.args.rows, 0)
         const cols = numberArg(msg.args.cols, 0)
         const data = Array.isArray(msg.args.data) ? (msg.args.data as string[][]) : undefined
-        const position = (typeof msg.args.position === 'string' ? msg.args.position : 'end') as 'before' | 'after' | 'end'
+        const position = (typeof msg.args.position === 'string' ? msg.args.position : 'end') as
+          | 'before'
+          | 'after'
+          | 'end'
         const parsedRef = parseRef(ref)
         const tableCount = sections[parsedRef.section]?.tables.length ?? 0
         await holder.applyOperations([{ type: 'addTable', ref, rows, cols, data, position }])

--- a/src/formats/hwp/mutator.test.ts
+++ b/src/formats/hwp/mutator.test.ts
@@ -323,7 +323,11 @@ describe('mutateHwpCfb addTable', () => {
     const cfb = CFB.read(fixture, { type: 'buffer' })
     const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
 
-    mutateHwpCfb(cfb, [{ type: 'addTable', ref: 's0', rows: 1, cols: 1, position: 'end', data: [['Cell']] }], compressed)
+    mutateHwpCfb(
+      cfb,
+      [{ type: 'addTable', ref: 's0', rows: 1, cols: 1, position: 'end', data: [['Cell']] }],
+      compressed,
+    )
 
     const outPath = tmpPath('mutator-addTable-preserve')
     await writeFile(outPath, Buffer.from(CFB.write(cfb, { type: 'buffer' })))
@@ -347,7 +351,10 @@ describe('mutateHwpCfb addTable', () => {
 
     const outPath = tmpPath('mutator-addTable-position-end-out')
     await writeFile(outPath, Buffer.from(CFB.write(cfb, { type: 'buffer' })))
-    const hwpxPath = join(tmpdir(), `mutator-addTable-position-end-${Date.now()}-${Math.random().toString(36).slice(2)}.hwpx`)
+    const hwpxPath = join(
+      tmpdir(),
+      `mutator-addTable-position-end-${Date.now()}-${Math.random().toString(36).slice(2)}.hwpx`,
+    )
 
     try {
       const doc = await loadHwp(outPath)
@@ -374,7 +381,10 @@ describe('mutateHwpCfb addTable', () => {
 
     const outPath = tmpPath('mutator-addTable-position-before-out')
     await writeFile(outPath, Buffer.from(CFB.write(cfb, { type: 'buffer' })))
-    const hwpxPath = join(tmpdir(), `mutator-addTable-position-before-${Date.now()}-${Math.random().toString(36).slice(2)}.hwpx`)
+    const hwpxPath = join(
+      tmpdir(),
+      `mutator-addTable-position-before-${Date.now()}-${Math.random().toString(36).slice(2)}.hwpx`,
+    )
 
     try {
       const doc = await loadHwp(outPath)
@@ -401,12 +411,19 @@ describe('mutateHwpCfb addTable', () => {
 
     const outPath = tmpPath('mutator-addTable-position-after-out')
     await writeFile(outPath, Buffer.from(CFB.write(cfb, { type: 'buffer' })))
-    const hwpxPath = join(tmpdir(), `mutator-addTable-position-after-${Date.now()}-${Math.random().toString(36).slice(2)}.hwpx`)
+    const hwpxPath = join(
+      tmpdir(),
+      `mutator-addTable-position-after-${Date.now()}-${Math.random().toString(36).slice(2)}.hwpx`,
+    )
 
     try {
       const doc = await loadHwp(outPath)
       expect(doc.sections[0].tables).toHaveLength(1)
-      expect(doc.sections[0].paragraphs.map((p) => p.runs.map((r) => r.text).join(''))).toEqual(['PARA_A', '', 'PARA_B'])
+      expect(doc.sections[0].paragraphs.map((p) => p.runs.map((r) => r.text).join(''))).toEqual([
+        'PARA_A',
+        '',
+        'PARA_B',
+      ])
 
       await convertCommand(outPath, hwpxPath, { force: true })
       const zip = await JSZip.loadAsync(await readFile(hwpxPath))

--- a/src/shared/edit-types.ts
+++ b/src/shared/edit-types.ts
@@ -11,7 +11,14 @@ export type EditOperation =
   | { type: 'setText'; ref: string; text: string }
   | { type: 'setFormat'; ref: string; format: FormatOptions; start?: number; end?: number }
   | { type: 'setTableCell'; ref: string; text: string }
-  | { type: 'addTable'; ref: string; rows: number; cols: number; data?: string[][]; position: 'before' | 'after' | 'end' }
+  | {
+      type: 'addTable'
+      ref: string
+      rows: number
+      cols: number
+      data?: string[][]
+      position: 'before' | 'after' | 'end'
+    }
   | {
       type: 'addParagraph'
       ref: string

--- a/src/shared/edit-types.ts
+++ b/src/shared/edit-types.ts
@@ -11,7 +11,7 @@ export type EditOperation =
   | { type: 'setText'; ref: string; text: string }
   | { type: 'setFormat'; ref: string; format: FormatOptions; start?: number; end?: number }
   | { type: 'setTableCell'; ref: string; text: string }
-  | { type: 'addTable'; ref: string; rows: number; cols: number; data?: string[][] }
+  | { type: 'addTable'; ref: string; rows: number; cols: number; data?: string[][]; position: 'before' | 'after' | 'end' }
   | {
       type: 'addParagraph'
       ref: string


### PR DESCRIPTION
## Summary

Add `<ref>` parameter and `--position before|after|end` option to the `table add` command, enabling tables to be inserted at specific positions in a document instead of always appending to the end. Follows the existing `paragraph add` pattern at every layer.

## Problem

The `table add` command always appended tables to the end of section 0. This prevented inserting tables between existing paragraphs — e.g., when converting a Markdown document with tables interspersed in content, all tables ended up at the bottom.

## Changes

### CLI (`src/cli.ts`, `src/commands/table.ts`)
- **Breaking**: CLI signature changed from `table add <file> <rows> <cols>` to `table add <file> <ref> <rows> <cols>`.
- Add `--position before|after|end` option (default: `end`).
- Validate that `before`/`after` requires a paragraph ref (e.g., `s0.p0`); section-only refs (e.g., `s0`) are only valid for `end`.

### Type system (`src/shared/edit-types.ts`)
- Add required `position: 'before' | 'after' | 'end'` field to `addTable` operation type.

### HWPX mutator (`src/formats/hwpx/mutator.ts`)
- `addTableToSection()` now accepts `position` and `ref` parameters.
- `position='end'`: existing push behavior preserved.
- `position='before'`/`'after'`: iterate section children, count `hp:p` elements to find target paragraph index, splice table node at the correct position.

### HWP mutator (`src/formats/hwp/mutator.ts`)
- Add `position` and `paragraph` fields to `SectionAddTableOperation`.
- `position='end'`: call `clearLastParagraphBit()` on existing stream before appending (fixes last-paragraph bit handling).
- `position='before'`/`'after'`: new `spliceTableRecords()` function counts level-0 `PARA_HEADER` records to find the target paragraph boundary, then splices binary table records at the correct offset.

### Daemon (`src/daemon/server.ts`)
- Forward `ref` and `position` args from daemon messages through to `applyOperations`.

### Tests
- New unit tests in `src/formats/hwpx/mutator.test.ts` and `src/formats/hwp/mutator.test.ts` covering all three positions with cross-validation (HWP→HWPX conversion).
- Updated all existing `e2e/table-add.test.ts` invocations to new 4-arg CLI signature.
- 5 new E2E tests: HWPX before/after (XML position verified), HWP before/after (cross-validated), and a dedicated HWP→HWPX cross-validation test.

### Docs
- Updated `README.md` and `README.en.md` usage examples to show new `<ref>` argument and `--position` option.

## Usage

```bash
# Backward-compatible append (unchanged behavior)
hwpilot table add document.hwpx s0 3 4

# Insert before a paragraph
hwpilot table add document.hwpx s0.p0 2 2 --position before

# Insert after a paragraph
hwpilot table add document.hwpx s0.p2 3 4 --position after

# With data at a specific position
hwpilot table add document.hwpx s0.p1 2 2 --position after --data '[["A","B"],["C","D"]]'
```

## Testing

- All 607 unit tests pass, 0 failures.
- All 15 E2E table-add tests pass, 0 failures.
- Typecheck and lint clean.
- Manual QA: 8/8 scenarios verified (HWPX before/after, HWP before/after, cross-format conversion, error case for invalid ref).