### PR TITLE
feat(validate): add --viewer option for Hancom Viewer validation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -253,7 +253,8 @@ program
   .command('validate <file>')
   .description('Validate HWP file structural integrity')
   .option('--pretty', 'Pretty-print JSON output')
-  .action(async (file: string, options: { pretty?: boolean }) => {
+  .option('--viewer', 'Also validate using Hancom Office HWP Viewer app (macOS only)')
+  .action(async (file: string, options: { pretty?: boolean; viewer?: boolean }) => {
     await validateCommand(file, options)
   })
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,14 +1,24 @@
+import type { CheckResult } from '@/formats/hwp/validator'
 import { validateHwp } from '@/formats/hwp/validator'
 import { handleError } from '@/shared/error-handler'
 import { formatOutput } from '@/shared/output'
+import { checkViewerCorruption } from '@/shared/viewer'
 
 type ValidateOptions = {
   pretty?: boolean
+  viewer?: boolean
 }
 
 export async function validateCommand(file: string, options: ValidateOptions): Promise<void> {
   try {
     const result = await validateHwp(file)
+
+    if (options.viewer) {
+      const viewerCheck = await runViewerCheck(file)
+      result.checks.push(viewerCheck)
+      result.valid = result.checks.every((c) => c.status !== 'fail')
+    }
+
     process.stdout.write(formatOutput(result, options.pretty) + '\n')
     if (!result.valid) {
       process.exit(1)
@@ -16,4 +26,20 @@ export async function validateCommand(file: string, options: ValidateOptions): P
   } catch (e) {
     handleError(e)
   }
+}
+
+async function runViewerCheck(filePath: string): Promise<CheckResult> {
+  const result = await checkViewerCorruption(filePath)
+  if (result.skipped) {
+    return { name: 'viewer', status: 'skip', message: 'Hancom Office HWP Viewer not found' }
+  }
+  if (result.corrupted) {
+    return {
+      name: 'viewer',
+      status: 'fail',
+      message: 'Hancom Office HWP Viewer detected corruption',
+      details: result.alert ? { alert: result.alert } : undefined,
+    }
+  }
+  return { name: 'viewer', status: 'pass' }
 }

--- a/src/shared/viewer.ts
+++ b/src/shared/viewer.ts
@@ -1,0 +1,136 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+const VIEWER_APP_NAME = 'Hancom Office HWP Viewer'
+const VIEWER_ALERT_TIMEOUT_MS = 3000
+
+export type ViewerCheckResult = {
+  corrupted: boolean
+  alert?: string
+  skipped: boolean
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function runCommand(cmd: string, args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    proc.on('close', (code) => {
+      resolve({ stdout, exitCode: code ?? 0 })
+    })
+    proc.on('error', () => {
+      resolve({ stdout: '', exitCode: 1 })
+    })
+  })
+}
+
+export async function isHwpViewerAvailable(): Promise<boolean> {
+  if (process.platform !== 'darwin') return false
+  const result = await runCommand('mdfind', ['kMDItemCFBundleIdentifier == "com.haansoft.HancomOfficeViewer.Mac"'])
+  if (result.stdout.trim().length > 0) return true
+  return existsSync('/Applications/Hancom Office HWP Viewer.app')
+}
+
+export async function checkViewerCorruption(filePath: string): Promise<ViewerCheckResult> {
+  const available = await isHwpViewerAvailable()
+  if (!available) {
+    return { corrupted: false, skipped: true }
+  }
+
+  // Snapshot existing PIDs
+  const existingPidsResult = await runCommand('pgrep', ['-f', VIEWER_APP_NAME])
+  const existingPids = new Set(existingPidsResult.stdout.trim().split('\n').filter(Boolean))
+
+  // Open with OS-level hiding
+  await runCommand('open', ['-g', '-j', '-a', VIEWER_APP_NAME, filePath])
+
+  // Continuously force-hide the process (catches alerts that bypass -g -j)
+  const keepHiddenScript = `
+repeat 100 times
+  delay 0.1
+  tell application "System Events"
+    if exists process "${VIEWER_APP_NAME}" then
+      set visible of process "${VIEWER_APP_NAME}" to false
+    end if
+  end tell
+end repeat
+`
+  const hideProc = spawn('osascript', ['-e', keepHiddenScript], { stdio: 'ignore' })
+
+  // Wait for app to initialize (hide loop runs concurrently)
+  await sleep(VIEWER_ALERT_TIMEOUT_MS)
+
+  // Read alert via osascript with timeout
+  const alertText = await readViewerAlert()
+
+  // Stop continuous hiding
+  hideProc.kill()
+
+  // Check for corruption keywords
+  const corrupted = alertText.includes('손상') || alertText.includes('변조') || alertText.includes('복구')
+
+  // Quit viewer
+  await runCommand('osascript', ['-e', `tell application "${VIEWER_APP_NAME}" to quit`])
+
+  // Kill stray processes
+  await sleep(2000)
+  const strayPidsResult = await runCommand('pgrep', ['-f', VIEWER_APP_NAME])
+  const strayPids = strayPidsResult.stdout.trim().split('\n').filter(Boolean)
+  for (const pid of strayPids) {
+    if (!existingPids.has(pid)) {
+      await runCommand('kill', [pid])
+    }
+  }
+
+  return { corrupted, alert: alertText || undefined, skipped: false }
+}
+
+async function readViewerAlert(): Promise<string> {
+  const script = `
+tell application "System Events"
+  tell process "Hancom Office HWP Viewer"
+    set winCount to count of windows
+    if winCount > 1 then
+      set alertText to ""
+      repeat with w in windows
+        try
+          set texts to value of static texts of w
+          repeat with t in texts
+            set alertText to alertText & t
+          end repeat
+        end try
+      end repeat
+      return alertText
+    end if
+    return ""
+  end tell
+end tell
+`
+
+  return new Promise((resolve) => {
+    const proc = spawn('osascript', ['-e', script], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    const timeout = setTimeout(() => {
+      proc.kill()
+      resolve('')
+    }, 5000)
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    proc.on('close', () => {
+      clearTimeout(timeout)
+      resolve(stdout.trim())
+    })
+    proc.on('error', () => {
+      clearTimeout(timeout)
+      resolve('')
+    })
+  })
+}


### PR DESCRIPTION
## Summary

Add `--viewer` flag to the `validate` command that opens the file in Hancom Office HWP Viewer and checks for corruption alerts. macOS only.

## Changes

### Viewer module (`src/shared/viewer.ts`)
- New module with `isHwpViewerAvailable()` and `checkViewerCorruption()` functions.
- Uses Node.js `child_process.spawn` for compatibility with both Bun and Node runtimes.
- Opens the file hidden (`open -g -j`), waits for alerts, reads alert text via AppleScript, then quits the viewer and kills stray processes.
- Detects corruption by checking for keywords: 손상, 변조, 복구.

### Validate command (`src/commands/validate.ts`)
- Add `viewer?: boolean` option.
- When `--viewer` is passed, run `checkViewerCorruption()` and append a `viewer` check to the `checks` array.
- Recompute `valid` field to include the viewer result.

### CLI (`src/cli.ts`)
- Register `--viewer` option on the `validate` command.

## Usage

```bash
hwpilot validate document.hwp --viewer
```

## Viewer check statuses

| Status | Meaning |
|--------|---------|
| `pass` | Viewer opened the file without corruption alerts. |
| `fail` | Viewer detected corruption (alert contains 손상/변조/복구). |
| `skip` | Viewer app not installed or not on macOS. |