### PR TITLE
fix: prevent flaky CI tests from timing-dependent collisions

### DIFF
--- a/src/daemon/holder-hwp.ts
+++ b/src/daemon/holder-hwp.ts
@@ -137,7 +137,7 @@ export class HwpHolder {
     if (!this.fileStats) return
     try {
       const stats = await stat(this.filePath)
-      if (stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs) {
+      if (stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs || stats.size !== this.fileStats.size) {
         if (this.dirty) {
           console.warn(`File replaced externally while holder had unflushed changes: ${this.filePath}`)
         }

--- a/src/daemon/holder-hwp.ts
+++ b/src/daemon/holder-hwp.ts
@@ -137,7 +137,11 @@ export class HwpHolder {
     if (!this.fileStats) return
     try {
       const stats = await stat(this.filePath)
-      if (stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs || stats.size !== this.fileStats.size) {
+      if (
+        stats.ino !== this.fileStats.ino ||
+        stats.mtimeMs > this.fileStats.mtimeMs ||
+        stats.size !== this.fileStats.size
+      ) {
         if (this.dirty) {
           console.warn(`File replaced externally while holder had unflushed changes: ${this.filePath}`)
         }

--- a/src/daemon/holder-hwpx.ts
+++ b/src/daemon/holder-hwpx.ts
@@ -103,7 +103,7 @@ export class HwpxHolder {
     if (!this.fileStats) return
     try {
       const stats = await stat(this.filePath)
-      if (stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs) {
+      if (stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs || stats.size !== this.fileStats.size) {
         if (this.dirty) {
           console.warn(`File replaced externally while holder had unflushed changes: ${this.filePath}`)
         }

--- a/src/daemon/holder-hwpx.ts
+++ b/src/daemon/holder-hwpx.ts
@@ -103,7 +103,11 @@ export class HwpxHolder {
     if (!this.fileStats) return
     try {
       const stats = await stat(this.filePath)
-      if (stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs || stats.size !== this.fileStats.size) {
+      if (
+        stats.ino !== this.fileStats.ino ||
+        stats.mtimeMs > this.fileStats.mtimeMs ||
+        stats.size !== this.fileStats.size
+      ) {
         if (this.dirty) {
           console.warn(`File replaced externally while holder had unflushed changes: ${this.filePath}`)
         }

--- a/src/daemon/state-file.test.ts
+++ b/src/daemon/state-file.test.ts
@@ -15,6 +15,11 @@ import {
   writeStateFileExclusive,
 } from './state-file'
 
+let testDirCounter = 0
+function uniqueTestDir(): string {
+  return join(tmpdir(), `state-test-${Date.now()}-${++testDirCounter}`)
+}
+
 describe('state-file', () => {
   describe('getStateFilePath', () => {
     it('returns same path for same file', () => {
@@ -30,7 +35,7 @@ describe('state-file', () => {
     })
 
     it('resolves symlinks to same state file path', async () => {
-      const testDir = join(tmpdir(), `state-test-${Date.now()}`)
+      const testDir = uniqueTestDir()
       mkdirSync(testDir, { recursive: true })
 
       try {
@@ -67,11 +72,12 @@ describe('state-file', () => {
     let testDir: string
 
     beforeEach(() => {
-      testDir = join(tmpdir(), `state-test-${Date.now()}`)
+      testDir = uniqueTestDir()
       mkdirSync(testDir, { recursive: true })
     })
 
     afterEach(async () => {
+      deleteStateFile(join(testDir, 'test.hwpx'))
       await rm(testDir, { recursive: true, force: true })
     })
 
@@ -122,7 +128,7 @@ describe('state-file', () => {
     let testDir: string
 
     beforeEach(() => {
-      testDir = join(tmpdir(), `state-test-${Date.now()}`)
+      testDir = uniqueTestDir()
       mkdirSync(testDir, { recursive: true })
     })
 
@@ -188,11 +194,12 @@ describe('state-file', () => {
     let testDir: string
 
     beforeEach(() => {
-      testDir = join(tmpdir(), `state-test-${Date.now()}`)
+      testDir = uniqueTestDir()
       mkdirSync(testDir, { recursive: true })
     })
 
     afterEach(async () => {
+      deleteStateFile(join(testDir, 'test.hwpx'))
       await rm(testDir, { recursive: true, force: true })
     })
 
@@ -229,7 +236,7 @@ describe('state-file', () => {
     let testDir: string
 
     beforeEach(() => {
-      testDir = join(tmpdir(), `state-test-${Date.now()}`)
+      testDir = uniqueTestDir()
       mkdirSync(testDir, { recursive: true })
     })
 


### PR DESCRIPTION
## Summary

Fix two flaky CI test failures caused by timing-dependent behavior on fast runners.

## Problem 1: state-file test `Date.now()` collision

All describe blocks in `state-file.test.ts` used `Date.now()` for testDir naming. On fast CI, multiple `beforeEach` calls execute within the same millisecond → identical testDir paths → identical state file hashes. The `writeStateFile and readStateFile` describe block leaked state files (afterEach only removed testDir), so `writeStateFileExclusive` later found an existing file → `EEXIST`.

### Fix (`src/daemon/state-file.test.ts`)
- Add `uniqueTestDir()` helper with monotonic counter for guaranteed unique paths.
- Add `deleteStateFile()` cleanup in `afterEach` for describe blocks that leaked state files.

## Problem 2: holder file-change detection miss

`HwpxHolder.checkFileChanged()` uses `stats.ino !== saved.ino || stats.mtimeMs > saved.mtimeMs` to detect external file replacement. On fast CI, `unlink` + `writeFile` completes within the same millisecond (same mtime), and the OS can reuse the inode → neither check triggers → dirty in-memory state returned instead of fresh disk content.

### Fix (`src/daemon/holder-hwpx.ts`, `src/daemon/holder-hwp.ts`)
- Add `stats.size !== this.fileStats.size` to the change detection condition.
- Different content produces different-sized files, catching replacements that mtime and inode miss.

## Testing

- All 613 tests pass, 0 failures.
- Full `bun test src/` clean.