### PR TITLE
fix(daemon): detect external file replacement when stat metadata matches

### DIFF
--- a/src/daemon/holder-hwp.ts
+++ b/src/daemon/holder-hwp.ts
@@ -140,9 +140,7 @@ export class HwpHolder {
     try {
       const stats = await stat(this.filePath)
       let changed =
-        stats.ino !== this.fileStats.ino ||
-        stats.mtimeMs > this.fileStats.mtimeMs ||
-        stats.size !== this.fileStats.size
+        stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs || stats.size !== this.fileStats.size
 
       // When stats look unchanged but we have dirty state, verify content
       // hasn't changed. Stat metadata can match after fast delete+recreate

--- a/src/daemon/holder-hwp.ts
+++ b/src/daemon/holder-hwp.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import CFB from 'cfb'
 import type { FlushScheduler } from '@/daemon/flush'
@@ -17,6 +17,7 @@ export class HwpHolder {
   private headerCache: DocumentHeader | null = null
   private dirty = false
   private fileStats: { ino: number; mtimeMs: number; size: number } | null = null
+  private contentDigest: string | null = null
 
   constructor(filePath: string) {
     this.filePath = filePath
@@ -31,6 +32,7 @@ export class HwpHolder {
     this.dirty = false
     const stats = await stat(this.filePath)
     this.fileStats = { ino: stats.ino, mtimeMs: stats.mtimeMs, size: stats.size }
+    this.contentDigest = createHash('sha256').update(buffer).digest('hex')
   }
 
   async getSections(): Promise<Section[]> {
@@ -137,11 +139,21 @@ export class HwpHolder {
     if (!this.fileStats) return
     try {
       const stats = await stat(this.filePath)
-      if (
+      let changed =
         stats.ino !== this.fileStats.ino ||
         stats.mtimeMs > this.fileStats.mtimeMs ||
         stats.size !== this.fileStats.size
-      ) {
+
+      // When stats look unchanged but we have dirty state, verify content
+      // hasn't changed. Stat metadata can match after fast delete+recreate
+      // (inode reuse on tmpfs + same-ms mtime + same CFB-padded file size).
+      if (!changed && this.dirty && this.contentDigest) {
+        const buffer = await readFile(this.filePath)
+        const digest = createHash('sha256').update(buffer).digest('hex')
+        changed = digest !== this.contentDigest
+      }
+
+      if (changed) {
         if (this.dirty) {
           console.warn(`File replaced externally while holder had unflushed changes: ${this.filePath}`)
         }

--- a/src/daemon/holder-hwpx.ts
+++ b/src/daemon/holder-hwpx.ts
@@ -108,9 +108,7 @@ export class HwpxHolder {
     try {
       const stats = await stat(this.filePath)
       let changed =
-        stats.ino !== this.fileStats.ino ||
-        stats.mtimeMs > this.fileStats.mtimeMs ||
-        stats.size !== this.fileStats.size
+        stats.ino !== this.fileStats.ino || stats.mtimeMs > this.fileStats.mtimeMs || stats.size !== this.fileStats.size
 
       // When stats look unchanged but we have dirty state, verify content
       // hasn't changed. Stat metadata can match after fast delete+recreate


### PR DESCRIPTION
## Summary

Fix flaky CI test `HwpHolder file change detection > warns and discards dirty state when file is replaced externally` ([run #38](https://github.com/devxoul/hwpilot/actions/runs/22557247868/job/65336849927)). Add SHA-256 content digest fallback to `checkFileChanged()` in both `HwpHolder` and `HwpxHolder`.

## Problem

On Linux CI (tmpfs), a fast file delete+recreate cycle produces **identical stat metadata**:

| Stat field | Why it matches |
|---|---|
| `ino` | Inode reuse on tmpfs — freed inodes are immediately recycled. |
| `mtimeMs` | Both operations complete within the same millisecond. |
| `size` | HWP's CFB format uses fixed 512-byte sectors, so different short texts produce identical file sizes (verified: both `"Original"` and `"External replacement"` → 3584 bytes). |

The HWPX test never hit this because ZIP compression always produces different sizes for different content.

## Changes

### HwpHolder / HwpxHolder (`src/daemon/holder-hwp.ts`, `src/daemon/holder-hwpx.ts`)

- Compute SHA-256 digest of raw file content during `load()` and store as `contentDigest`.
- In `checkFileChanged()`, when stat metadata shows no change **and** the holder has dirty state, re-read the file and compare digests. If different, the file was replaced externally — discard dirty state and reload.
- Normal (non-dirty) operation remains a cheap stat-only check with zero additional I/O.

## Testing

- All 613 tests pass, 0 failures.
- Full `bun test src/` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect external file replacement even when inode, mtime, and size match by adding a SHA-256 digest fallback in HwpHolder and HwpxHolder, fixing the flaky CI test and correctly clearing dirty state on external replace. Also align multi-line condition formatting with Biome (no logic changes).

<sup>Written for commit 9fc82357bc1b8deddba28244c7eae6d844f857f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

