### PR TITLE
fix(hwp): resolve charShape validation failure on formatted paragraph add

### DIFF
--- a/src/formats/hwp/mutator.test.ts
+++ b/src/formats/hwp/mutator.test.ts
@@ -717,6 +717,31 @@ describe('mutateHwpCfb addParagraph heading/style', () => {
     }
   })
 
+  it('uses heading charShapeRef in PARA_CHAR_SHAPE record', async () => {
+    const hwpPath = tmpPath('mutator-addParagraph-heading-charshape')
+    await writeFile(hwpPath, await createHwp())
+
+    try {
+      const buffer = await readFile(hwpPath)
+      const cfb = CFB.read(buffer, { type: 'buffer' })
+      const compressed = getCompressionFlag(getEntryBuffer(cfb, '/FileHeader'))
+
+      mutateHwpCfb(
+        cfb,
+        [{ type: 'addParagraph', ref: 's0', text: 'Heading 2', position: 'end', heading: 2 }],
+        compressed,
+      )
+
+      // PARA_CHAR_SHAPE should reference charShape 2 (개요 2 heading charShape)
+      const charShapeData = await getParagraphCharShapeData(cfb, compressed, 1)
+      expect(charShapeData).not.toBeNull()
+      // 8-byte entry: [uint32 position=0][uint32 charShapeRef=2]
+      expect(charShapeData!.readUInt32LE(4)).toBe(2)
+    } finally {
+      await unlink(hwpPath)
+    }
+  })
+
   it('sets paraShapeRef and styleRef for heading level 3', async () => {
     const hwpPath = tmpPath('mutator-addParagraph-heading3')
     await writeFile(hwpPath, await createHwp())

--- a/src/formats/hwp/mutator.ts
+++ b/src/formats/hwp/mutator.ts
@@ -339,12 +339,12 @@ function resolveStyleRefs(
   compressed: boolean,
   heading?: number,
   style?: string | number,
-): { paraShapeRef: number; styleIndex: number } {
+): { paraShapeRef: number; styleIndex: number; charShapeRef: number } {
   if (heading !== undefined && style !== undefined) {
     throw new Error('Cannot specify both heading and style')
   }
   if (heading === undefined && style === undefined) {
-    return { paraShapeRef: 0, styleIndex: 0 }
+    return { paraShapeRef: 0, styleIndex: 0, charShapeRef: 0 }
   }
 
   const docInfoPath = '/DocInfo'
@@ -364,14 +364,16 @@ function resolveStyleRefs(
 
     if (targetIndex !== undefined && styleIdx === targetIndex) {
       const paraShapeRef = parseStyleParaShapeRef(data)
-      return { paraShapeRef, styleIndex: styleIdx }
+      const charShapeRef = parseStyleCharShapeRef(data)
+      return { paraShapeRef, styleIndex: styleIdx, charShapeRef }
     }
 
     if (targetName !== undefined) {
       const name = parseStyleKoreanName(data)
       if (name === targetName) {
         const paraShapeRef = parseStyleParaShapeRef(data)
-        return { paraShapeRef, styleIndex: styleIdx }
+        const charShapeRef = parseStyleCharShapeRef(data)
+        return { paraShapeRef, styleIndex: styleIdx, charShapeRef }
       }
     }
 
@@ -405,6 +407,16 @@ function parseStyleParaShapeRef(data: Buffer): number {
   return data.readUInt16LE(offset + 2)
 }
 
+function parseStyleCharShapeRef(data: Buffer): number {
+  const nameLen = data.readUInt16LE(0)
+  let offset = 2 + nameLen * 2
+  if (offset + 2 > data.length) return 0
+  const englishNameLen = data.readUInt16LE(offset)
+  offset += 2 + englishNameLen * 2
+  if (offset + 2 > data.length) return 0
+  return data.readUInt16LE(offset)
+}
+
 function appendParagraphRecords(
   stream: Buffer,
   op: SectionAddParagraphOperation,
@@ -414,10 +426,16 @@ function appendParagraphRecords(
 ): Buffer {
   void sectionIndex
 
-  const { paraShapeRef, styleIndex } = resolveStyleRefs(cfb, compressed, op.heading, op.style)
+  const {
+    paraShapeRef,
+    styleIndex,
+    charShapeRef: styleCharShapeRef,
+  } = resolveStyleRefs(cfb, compressed, op.heading, op.style)
 
   const charShapeRef =
-    op.format && hasFormatOptions(op.format) ? addCharShapeWithFormat(cfb, compressed, 0, op.format) : 0
+    op.format && hasFormatOptions(op.format)
+      ? addCharShapeWithFormat(cfb, compressed, styleCharShapeRef, op.format)
+      : styleCharShapeRef
 
   const textData = Buffer.from(op.text, 'utf16le')
   const isEmpty = textData.length === 0

--- a/src/formats/hwp/validator.test.ts
+++ b/src/formats/hwp/validator.test.ts
@@ -3,10 +3,12 @@ import { readFile } from 'node:fs/promises'
 import CFB from 'cfb'
 import { createTestHwpBinary, createTestHwpCfb, createTestHwpx } from '../../test-helpers'
 import { controlIdBuffer } from './control-id'
+import { createHwp } from './creator'
 import { iterateRecords } from './record-parser'
 import { buildCellListHeaderData, buildRecord, buildTableData, replaceRecordData } from './record-serializer'
 import { TAG } from './tag-ids'
 import { validateHwp, validateHwpBuffer } from './validator'
+import { editHwp } from './writer'
 
 const TMP_FILES: string[] = []
 
@@ -350,6 +352,32 @@ describe('validateHwp', () => {
       const result = await validateHwp(filePath)
 
       // Guard kicks in: 1 < 10 → check skipped → pass
+      expect(getCheckStatus(result, 'content_completeness')).toBe('pass')
+    })
+
+    it('passes on created HWP with formatted paragraphs (pre-allocated heading charShapes)', async () => {
+      // createHwp declares 8 charShapes (1 body + 7 heading) and 8 styles.
+      // Adding formatted paragraphs pushes the count past the threshold of 10.
+      // Style-referenced charShapes should count toward coverage.
+      const filePath = tmpPath('validator-f-created-formatted')
+      TMP_FILES.push(filePath)
+      await Bun.write(filePath, await createHwp())
+
+      // Add formatting that creates new charShapes (pushing total to 10+)
+      await editHwp(filePath, [{ type: 'setFormat', ref: 's0.p0', format: { bold: true, fontSize: 22 } }])
+      await editHwp(filePath, [
+        {
+          type: 'addParagraph',
+          ref: 's0',
+          text: 'heading text',
+          position: 'end',
+          format: { bold: true, fontSize: 16 },
+        },
+      ])
+
+      const result = await validateHwp(filePath)
+
+      // Should pass because style-referenced charShapes (headings 1-7) count toward coverage
       expect(getCheckStatus(result, 'content_completeness')).toBe('pass')
     })
   })

--- a/src/formats/hwp/validator.ts
+++ b/src/formats/hwp/validator.ts
@@ -474,12 +474,25 @@ function validateIdMappings(docInfoBuffer: Buffer): CheckResult {
 }
 
 function validateContentCompleteness(docInfoBuffer: Buffer, sectionStreams: StreamRef[]): CheckResult {
-  const declaredCharShapeCount = parseRecords(docInfoBuffer).filter((record) => record.tagId === TAG.CHAR_SHAPE).length
+  const docInfoRecords = parseRecords(docInfoBuffer)
+  const declaredCharShapeCount = docInfoRecords.filter((record) => record.tagId === TAG.CHAR_SHAPE).length
   if (declaredCharShapeCount < 10) {
     return { name: 'content_completeness', status: 'pass' }
   }
 
   const uniqueRefs = new Set<number>()
+
+  // Count charShapes referenced by STYLE records in DocInfo.
+  // Pre-allocated styles (e.g. heading charShapes) are legitimately declared even if no
+  // body paragraph uses them yet.
+  for (const record of docInfoRecords) {
+    if (record.tagId !== TAG.STYLE) continue
+    const ref = parseStyleCharShapeRef(record.data)
+    if (ref >= 0 && ref < declaredCharShapeCount) {
+      uniqueRefs.add(ref)
+    }
+  }
+
   for (const stream of sectionStreams) {
     const records = parseRecords(stream.buffer)
     for (const record of records) {
@@ -513,6 +526,19 @@ function validateContentCompleteness(docInfoBuffer: Buffer, sectionStreams: Stre
   }
 
   return { name: 'content_completeness', status: 'pass' }
+}
+
+// Extract charShapeRef from a STYLE record's binary data.
+// Layout: [uint16 koreanNameLen][koreanName][uint16 englishNameLen][englishName][uint16 charShapeRef][uint16 paraShapeRef]
+function parseStyleCharShapeRef(data: Buffer): number {
+  if (data.length < 2) return -1
+  const nameLen = data.readUInt16LE(0)
+  let offset = 2 + nameLen * 2
+  if (offset + 2 > data.length) return -1
+  const englishNameLen = data.readUInt16LE(offset)
+  offset += 2 + englishNameLen * 2
+  if (offset + 2 > data.length) return -1
+  return data.readUInt16LE(offset)
 }
 
 function validateParagraphCompleteness(sectionStreams: StreamRef[]): CheckResult {


### PR DESCRIPTION
## Summary

Fix `content_completeness` validation false positive on newly created HWP files when adding formatted paragraphs. Also fix heading paragraphs using wrong charShape (body default instead of heading charShape).

## Problem

Adding formatted paragraphs (`--bold --size`) to a freshly created `.hwp` file failed with:

```
HWP validation failed: content_completeness: Body text references only 3 of 10 declared charShapes (30.0%)
```

**Root cause**: `createHwp` pre-allocates 8 charShapes (1 body + 7 heading). After two formatting operations push the count to 10, the validator's `< 10` skip threshold is crossed, and with only 3 charShapes referenced by body text (0, 8, 9), coverage is 30% — below the 50% threshold. The 7 heading charShapes are legitimately declared (referenced by STYLE records) but the validator only checked body text `PARA_CHAR_SHAPE` records.

## Changes

### Validator (`validator.ts`)
- `validateContentCompleteness` now parses STYLE records from DocInfo and adds their `charShapeRef` values to the coverage set before checking the ratio. Style-referenced charShapes are legitimately in use even if no body paragraph uses them yet.

### Mutator (`mutator.ts`)
- `resolveStyleRefs` now returns `charShapeRef` alongside `paraShapeRef` and `styleIndex`.
- `appendParagraphRecords` uses the style's charShapeRef so heading paragraphs get correct character formatting (bold, larger font) instead of always falling back to charShape 0 (body default).
- When `--heading` is combined with explicit format options, the heading charShape is cloned as source instead of the body charShape.

## Testing

- `src/`: 618 pass, 0 fail (+2 new tests).
- `e2e/`: 18 pre-existing failures, 0 new.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false content_completeness failures on new HWP files when adding formatted paragraphs. Also ensures heading paragraphs use their style’s charShape instead of the body default.

- **Bug Fixes**
  - Validator counts STYLE-referenced charShapes toward coverage, so pre-allocated heading charShapes no longer trigger false failures.
  - Added parseStyleCharShapeRef to extract charShapeRef from STYLE records in DocInfo.
  - Mutator returns and uses the style’s charShapeRef when appending paragraphs; if format options are set, it clones from the heading charShape.

<sup>Written for commit 21206fe4000bdfd2731373dea594474add1d6d39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

