### PR TITLE
fix(hwp): align generated HWP structure with Hancom app expectations

### DIFF
--- a/src/formats/hwp/creator.test.ts
+++ b/src/formats/hwp/creator.test.ts
@@ -2,11 +2,15 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import CFB from 'cfb'
 import JSZip from 'jszip'
 import { convertCommand } from '../../commands/convert'
 import { createTestHwpBinary } from '../../test-helpers'
 import { createHwp } from './creator'
 import { loadHwp } from './reader'
+import { iterateRecords } from './record-parser'
+import { decompressStream, getCompressionFlag } from './stream-util'
+import { TAG } from './tag-ids'
 
 const TMP_FILES: string[] = []
 
@@ -168,6 +172,68 @@ describe('createHwp', () => {
         expect(style?.charShapeRef).toBe(i)
         expect(style?.paraShapeRef).toBe(i)
       }
+    })
+
+    it('writes full PARA_SHAPE/STYLE payloads and section dloc control', async () => {
+      const fixture = await createHwp({ compressed: true })
+      const cfb = CFB.read(fixture, { type: 'buffer' })
+
+      const fileHeader = CFB.find(cfb, '/FileHeader')
+      expect(fileHeader?.content).toBeDefined()
+      const fileHeaderBuffer = Buffer.from(fileHeader!.content as Uint8Array)
+      expect(fileHeaderBuffer.readUInt32LE(32)).toBe(0x05010100)
+      expect(fileHeaderBuffer[32]).toBe(0x00)
+      expect(fileHeaderBuffer[33]).toBe(0x01)
+
+      const compressed = getCompressionFlag(fileHeaderBuffer)
+      const docInfoEntry = CFB.find(cfb, '/DocInfo')
+      expect(docInfoEntry?.content).toBeDefined()
+      let docInfo = Buffer.from(docInfoEntry!.content as Uint8Array)
+      if (compressed) {
+        docInfo = Buffer.from(decompressStream(docInfo))
+      }
+
+      const paraShapeSizes: number[] = []
+      const styleTrailingSizes: number[] = []
+      for (const { header, data } of iterateRecords(docInfo)) {
+        if (header.tagId === TAG.PARA_SHAPE) {
+          paraShapeSizes.push(data.length)
+        }
+        if (header.tagId === TAG.STYLE) {
+          const nameLen = data.readUInt16LE(0)
+          let offset = 2 + nameLen * 2
+          const englishNameLen = data.readUInt16LE(offset)
+          offset += 2 + englishNameLen * 2
+          styleTrailingSizes.push(data.length - offset)
+        }
+      }
+
+      expect(paraShapeSizes.length).toBeGreaterThanOrEqual(8)
+      expect(paraShapeSizes[0]).toBe(58)
+      for (const size of paraShapeSizes.slice(1, 8)) {
+        expect(size).toBe(58)
+      }
+
+      expect(styleTrailingSizes.length).toBeGreaterThanOrEqual(8)
+      for (const size of styleTrailingSizes.slice(1, 8)) {
+        expect(size).toBeGreaterThanOrEqual(10)
+      }
+
+      const section0Entry = CFB.find(cfb, '/BodyText/Section0')
+      expect(section0Entry?.content).toBeDefined()
+      let section0 = Buffer.from(section0Entry!.content as Uint8Array)
+      if (compressed) {
+        section0 = Buffer.from(decompressStream(section0))
+      }
+
+      expect(section0.includes(Buffer.from('cold', 'ascii'))).toBe(true)
+      const dlocCtrlHeader = [...iterateRecords(section0)].find(
+        ({ header, data }) =>
+          header.tagId === TAG.CTRL_HEADER && header.level === 1 && data.subarray(0, 4).toString('ascii') === 'dloc',
+      )
+      expect(dlocCtrlHeader).toBeDefined()
+      expect(dlocCtrlHeader!.data.length).toBe(16)
+      expect(dlocCtrlHeader!.data.readUInt32LE(4)).toBe(0x00001004)
     })
   })
 })

--- a/src/formats/hwp/creator.ts
+++ b/src/formats/hwp/creator.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import CFB from 'cfb'
+import { controlIdBuffer } from './control-id'
 import { iterateRecords } from './record-parser'
 import { buildParaLineSegBuffer, buildRecord } from './record-serializer'
 import { compressStream, decompressStream, getCompressionFlag } from './stream-util'
@@ -109,6 +110,7 @@ function patchDocInfo(
   let charShapeIndex = 0
   let paraShapeIndex = 0
   let styleIndex = 0
+  let bodyParaShapeData: Buffer | null = null
   for (const { header, data, offset } of iterateRecords(stream)) {
     const recordBuf = stream.subarray(offset, offset + header.headerSize + header.size)
     if (header.tagId === TAG.FACE_NAME && font) {
@@ -138,9 +140,10 @@ function patchDocInfo(
 
     if (header.tagId === TAG.PARA_SHAPE) {
       if (paraShapeIndex === 0) {
+        bodyParaShapeData = Buffer.from(data)
         parts.push(recordBuf)
         // Add 7 heading paraShapes after body
-        for (const headingParaShape of buildHeadingParaShapes()) {
+        for (const headingParaShape of buildHeadingParaShapes(bodyParaShapeData)) {
           parts.push(buildRecord(TAG.PARA_SHAPE, header.level, headingParaShape))
         }
       }
@@ -158,9 +161,12 @@ function patchDocInfo(
           const englishNameLen = patched.readUInt16LE(refOffset)
           refOffset += 2 + englishNameLen * 2
         }
-        if (refOffset + 4 <= patched.length) {
-          patched.writeUInt16LE(0, refOffset) // charShapeRef = 0
-          patched.writeUInt16LE(0, refOffset + 2) // paraShapeRef = 0
+        if (refOffset + 10 <= patched.length) {
+          patched.writeUInt16LE(0, refOffset + 4)
+          patched.writeUInt16LE(0, refOffset + 6)
+        } else if (refOffset + 4 <= patched.length) {
+          patched.writeUInt16LE(0, refOffset)
+          patched.writeUInt16LE(0, refOffset + 2)
         }
         parts.push(buildRecord(TAG.STYLE, header.level, patched))
         // Add 7 heading styles after body
@@ -209,12 +215,14 @@ function buildHeadingCharShapes(bodyCharShapeData: Buffer): Buffer[] {
   })
 }
 
-function buildHeadingParaShapes(): Buffer[] {
+function buildHeadingParaShapes(bodyParaShapeData: Buffer): Buffer[] {
   return Array.from({ length: 7 }, (_, i) => {
     const level = i + 1
-    const buf = Buffer.alloc(4)
-    // bits 2-4: alignment=1 (left), bits 25-27: heading level
-    buf.writeUInt32LE(((level << 25) | (1 << 2)) >>> 0, 0)
+    const buf = Buffer.from(bodyParaShapeData)
+    const flags = buf.readUInt32LE(0)
+    const cleared = flags & ~(0x7 | (0x7 << 25))
+    const newFlags = cleared | (1 << 2) | (level << 25)
+    buf.writeUInt32LE(newFlags >>> 0, 0)
     return buf
   })
 }
@@ -222,13 +230,18 @@ function buildHeadingParaShapes(): Buffer[] {
 function buildHeadingStyles(): Buffer[] {
   return Array.from({ length: 7 }, (_, i) => {
     const level = i + 1
+    const styleIndex = level
     const koreanName = encodeLengthPrefixedUtf16(`\uAC1C\uC694 ${level}`)
     const englishNameLen = Buffer.alloc(2)
     englishNameLen.writeUInt16LE(0, 0)
-    const refs = Buffer.alloc(4)
-    refs.writeUInt16LE(level, 0) // charShapeRef
-    refs.writeUInt16LE(level, 2) // paraShapeRef
-    return Buffer.concat([koreanName, englishNameLen, refs])
+    const trailing = Buffer.alloc(10)
+    trailing.writeUInt8(0, 0)
+    trailing.writeUInt8(styleIndex, 1)
+    trailing.writeInt16LE(0x0412, 2)
+    trailing.writeUInt16LE(level, 4)
+    trailing.writeUInt16LE(level, 6)
+    trailing.writeUInt16LE(0, 8)
+    return Buffer.concat([koreanName, englishNameLen, trailing])
   })
 }
 
@@ -241,21 +254,28 @@ function encodeLengthPrefixedUtf16(text: string): Buffer {
 
 function buildSection0Stream(sectionDef: Buffer): Buffer {
   const contentWidth = extractContentWidthFromRecords(sectionDef)
-  // Single empty paragraph with section definition
   const sectionCtrlChar = Buffer.alloc(16)
   sectionCtrlChar.writeUInt16LE(0x0002, 0)
-  sectionCtrlChar.write('dces', 2, 'ascii')
+  controlIdBuffer('secd').copy(sectionCtrlChar, 2)
   sectionCtrlChar.writeUInt16LE(0x0002, 14)
-  const paraText = Buffer.concat([sectionCtrlChar, Buffer.from([0x0d, 0x00])])
+  const columnCtrlChar = Buffer.alloc(16)
+  columnCtrlChar.writeUInt16LE(0x0002, 0)
+  controlIdBuffer('dloc').copy(columnCtrlChar, 2)
+  columnCtrlChar.writeUInt16LE(0x0002, 14)
+  const paraText = Buffer.concat([sectionCtrlChar, columnCtrlChar, Buffer.from([0x0d, 0x00])])
   const nChars = paraText.length / 2
   const paraHeader = buildParaHeader(nChars, true)
-  paraHeader.writeUInt32LE(0x00080004, 4)
+  paraHeader.writeUInt32LE(0x00000004, 4)
+  const dlocCtrlData = Buffer.alloc(16)
+  controlIdBuffer('cold').copy(dlocCtrlData, 0)
+  dlocCtrlData.writeUInt32LE(0x00001004, 4)
   return Buffer.concat([
     buildRecord(TAG.PARA_HEADER, 0, paraHeader),
     buildRecord(TAG.PARA_TEXT, 1, paraText),
     buildRecord(TAG.PARA_CHAR_SHAPE, 1, buildParaCharShape(0, nChars)),
     buildRecord(TAG.PARA_LINE_SEG, 1, buildParaLineSegBuffer(contentWidth)),
     sectionDef,
+    buildRecord(TAG.CTRL_HEADER, 1, dlocCtrlData),
   ])
 }
 
@@ -308,7 +328,7 @@ function extractContentWidthFromRecords(recordStream: Buffer): number {
 function createHwpFileHeader(compressed: boolean): Buffer {
   const fileHeader = Buffer.alloc(256)
   fileHeader.write('HWP Document File', 0, 'ascii')
-  fileHeader.writeUInt32LE(0x05010001, 32)
+  fileHeader.writeUInt32LE(0x05010100, 32)
   fileHeader.writeUInt32LE(compressed ? 0x1 : 0, 36)
   fileHeader.writeUInt32LE(4, 44)
   return fileHeader

--- a/src/formats/hwp/mutator.ts
+++ b/src/formats/hwp/mutator.ts
@@ -402,9 +402,14 @@ function parseStyleParaShapeRef(data: Buffer): number {
   if (offset + 2 > data.length) return 0
   const englishNameLen = data.readUInt16LE(offset)
   offset += 2 + englishNameLen * 2
-  // charShapeRef (uint16) + paraShapeRef (uint16)
-  if (offset + 4 > data.length) return 0
-  return data.readUInt16LE(offset + 2)
+  const remaining = data.length - offset
+  if (remaining >= 10) {
+    return data.readUInt16LE(offset + 6)
+  }
+  if (remaining >= 4) {
+    return data.readUInt16LE(offset + 2)
+  }
+  return 0
 }
 
 function parseStyleCharShapeRef(data: Buffer): number {
@@ -413,8 +418,14 @@ function parseStyleCharShapeRef(data: Buffer): number {
   if (offset + 2 > data.length) return 0
   const englishNameLen = data.readUInt16LE(offset)
   offset += 2 + englishNameLen * 2
-  if (offset + 2 > data.length) return 0
-  return data.readUInt16LE(offset)
+  const remaining = data.length - offset
+  if (remaining >= 10) {
+    return data.readUInt16LE(offset + 4)
+  }
+  if (remaining >= 2) {
+    return data.readUInt16LE(offset)
+  }
+  return 0
 }
 
 function appendParagraphRecords(
@@ -832,24 +843,31 @@ function applySetFormat(
   const clonedCharShape = Buffer.from(sourceCharShape)
   applyFormatToCharShape(clonedCharShape, format)
 
-  const idMappings = findIdMappingsRecord(docInfoStream)
-  if (!idMappings || idMappings.data.length < 8) {
-    throw new Error('ID_MAPPINGS record not found or malformed')
-  }
+  const existingCharShapeRef = findCharShapeRecordIndex(docInfoStream, clonedCharShape)
+  const targetCharShapeRef =
+    existingCharShapeRef ??
+    (() => {
+      const idMappings = findIdMappingsRecord(docInfoStream)
+      if (!idMappings || idMappings.data.length < 8) {
+        throw new Error('ID_MAPPINGS record not found or malformed')
+      }
 
-  const charShapeCountOffset = findCharShapeCountOffset(idMappings.data, charShapeRecords.length)
-  const currentCharShapeCount = idMappings.data.readUInt32LE(charShapeCountOffset)
-  const patchedIdMappings = Buffer.from(idMappings.data)
-  patchedIdMappings.writeUInt32LE(currentCharShapeCount + 1, charShapeCountOffset)
-  docInfoStream = replaceRecordData(docInfoStream, idMappings.offset, patchedIdMappings)
+      const charShapeCountOffset = findCharShapeCountOffset(idMappings.data, charShapeRecords.length)
+      const currentCharShapeCount = idMappings.data.readUInt32LE(charShapeCountOffset)
+      const patchedIdMappings = Buffer.from(idMappings.data)
+      patchedIdMappings.writeUInt32LE(currentCharShapeCount + 1, charShapeCountOffset)
+      docInfoStream = replaceRecordData(docInfoStream, idMappings.offset, patchedIdMappings)
 
-  const insertionOffset = findLastCharShapeRecordEnd(docInfoStream)
-  const newRecord = buildRecord(TAG.CHAR_SHAPE, 1, clonedCharShape)
-  docInfoStream = Buffer.concat([
-    docInfoStream.subarray(0, insertionOffset),
-    newRecord,
-    docInfoStream.subarray(insertionOffset),
-  ])
+      const insertionOffset = findLastCharShapeRecordEnd(docInfoStream)
+      const newRecord = buildRecord(TAG.CHAR_SHAPE, 1, clonedCharShape)
+      docInfoStream = Buffer.concat([
+        docInfoStream.subarray(0, insertionOffset),
+        newRecord,
+        docInfoStream.subarray(insertionOffset),
+      ])
+
+      return currentCharShapeCount
+    })()
 
   const hasInlineRange = start !== undefined || end !== undefined
   if (hasInlineRange && (start === undefined || end === undefined)) {
@@ -868,7 +886,7 @@ function applySetFormat(
     if (start > 0) {
       entries.push({ pos: 0, ref: sourceCharShapeId })
     }
-    entries.push({ pos: start, ref: currentCharShapeCount })
+    entries.push({ pos: start, ref: targetCharShapeRef })
     if (end < textLength) {
       entries.push({ pos: end, ref: sourceCharShapeId })
     }
@@ -879,7 +897,7 @@ function applySetFormat(
       patchedParaCharShape.writeUInt32LE(entries[i].ref, i * 8 + 4)
     }
   } else {
-    patchedParaCharShape = writeParagraphCharShapeRef(paraCharShapeMatch.data, currentCharShapeCount)
+    patchedParaCharShape = writeParagraphCharShapeRef(paraCharShapeMatch.data, targetCharShapeRef)
   }
 
   sectionStream = replaceRecordData(sectionStream, paraCharShapeMatch.offset, patchedParaCharShape)
@@ -1114,6 +1132,11 @@ function addCharShapeWithFormat(
   const clonedCharShape = Buffer.from(sourceCharShape)
   applyFormatToCharShape(clonedCharShape, format)
 
+  const existingCharShapeRef = findCharShapeRecordIndex(docInfoStream, clonedCharShape)
+  if (existingCharShapeRef !== null) {
+    return existingCharShapeRef
+  }
+
   const idMappings = findIdMappingsRecord(docInfoStream)
   if (!idMappings || idMappings.data.length < 8) {
     throw new Error('ID_MAPPINGS record not found or malformed')
@@ -1135,6 +1158,19 @@ function addCharShapeWithFormat(
 
   CFB.utils.cfb_add(cfb, docInfoPath, compressed ? compressStream(docInfoStream) : docInfoStream)
   return currentCharShapeCount
+}
+
+function findCharShapeRecordIndex(stream: Buffer, target: Buffer): number | null {
+  let index = 0
+  for (const { header, data } of iterateRecords(stream)) {
+    if (header.tagId === TAG.CHAR_SHAPE) {
+      if (Buffer.compare(data, target) === 0) {
+        return index
+      }
+      index += 1
+    }
+  }
+  return null
 }
 
 function applyFormatToCharShape(charShape: Buffer, format: FormatOptions): void {

--- a/src/formats/hwp/reader.test.ts
+++ b/src/formats/hwp/reader.test.ts
@@ -701,6 +701,45 @@ describe('STYLE record parsing', () => {
     // Cleanup
     await Bun.file(filePath).delete()
   })
+
+  it('parses STYLE record with full trailing fields correctly', async () => {
+    const filePath = '/tmp/test-hwp-style-full-trailing.hwp'
+    const _TMP_FILES: string[] = [filePath]
+
+    const koreanName = Buffer.from('스타일', 'utf16le')
+    const koreanNameLen = Buffer.alloc(2)
+    koreanNameLen.writeUInt16LE(3, 0)
+
+    const englishNameLen = Buffer.alloc(2)
+    englishNameLen.writeUInt16LE(0, 0)
+
+    const trailing = Buffer.alloc(10)
+    trailing.writeUInt8(0, 0)
+    trailing.writeUInt8(1, 1)
+    trailing.writeInt16LE(0x0412, 2)
+    trailing.writeUInt16LE(5, 4)
+    trailing.writeUInt16LE(3, 6)
+    trailing.writeUInt16LE(0, 8)
+
+    const styleData = Buffer.concat([koreanNameLen, koreanName, englishNameLen, trailing])
+    const docInfoRecords = buildRecord(TAG.STYLE, 1, styleData)
+    const sectionRecords = Buffer.concat([
+      buildRecord(TAG.PARA_HEADER, 0, Buffer.alloc(0)),
+      buildRecord(TAG.PARA_TEXT, 1, encodeUint16([0x0000])),
+    ])
+
+    const buffer = createHwpCfbBufferWithRecords(0, docInfoRecords, sectionRecords)
+    await Bun.write(filePath, buffer)
+
+    const doc = await loadHwp(filePath)
+    const style = doc.header.styles[0]
+
+    expect(style.name).toBe('스타일')
+    expect(style.charShapeRef).toBe(5)
+    expect(style.paraShapeRef).toBe(3)
+
+    await Bun.file(filePath).delete()
+  })
 })
 
 // Test for PARA_SHAPE record with heading level

--- a/src/formats/hwp/reader.ts
+++ b/src/formats/hwp/reader.ts
@@ -240,19 +240,26 @@ function parseDocInfo(buffer: Buffer): DocInfoParseResult {
 
       const nameLen = data.readUInt16LE(0)
       let offset = 2 + nameLen * 2
-      // Skip English name if present
       if (offset + 2 <= data.length) {
         const englishNameLen = data.readUInt16LE(offset)
         offset += 2 + englishNameLen * 2
       }
+      const name = data.subarray(2, 2 + nameLen * 2).toString('utf16le')
+      const remaining = data.length - offset
 
-      if (offset + 4 > data.length) {
+      let charShapeRef: number
+      let paraShapeRef: number
+
+      if (remaining >= 10) {
+        charShapeRef = data.readUInt16LE(offset + 4)
+        paraShapeRef = data.readUInt16LE(offset + 6)
+      } else if (remaining >= 4) {
+        charShapeRef = data.readUInt16LE(offset)
+        paraShapeRef = data.readUInt16LE(offset + 2)
+      } else {
         continue
       }
 
-      const name = data.subarray(2, 2 + nameLen * 2).toString('utf16le')
-      const charShapeRef = data.readUInt16LE(offset)
-      const paraShapeRef = data.readUInt16LE(offset + 2)
       styles.push({ id: styleId, name, charShapeRef, paraShapeRef })
       styleId += 1
     }


### PR DESCRIPTION
## Summary

Fix HWP files generated by hwpilot being rejected by Hancom Docs and Hancom Viewer. Binary comparison of a hwpilot-generated file against a Hancom-created reference revealed five structural incompatibilities in record format, control streams, and file header.

## Problem

A file created via `hwpilot write --create` opened correctly in hwpilot but failed to load in other Hancom applications. Deep record-level comparison against a reference file created by the official Hancom app identified:

1. **Truncated PARA_SHAPE records** — 4-byte stubs instead of full 58-byte records.
2. **Incomplete STYLE records** — Missing trailing fields (type, nextStyleId, langId, charShapeRef, paraShapeRef, flags).
3. **Missing `dloc` control** — BodyText/Section0 lacked the column definition control Hancom expects.
4. **FileHeader version byte order** — `0x05010001` vs Hancom's `0x05010100`.
5. **Reader/mutator assumed legacy STYLE format** — Failed to parse full-format STYLE records from Hancom-created files, causing incorrect charShapeRef/paraShapeRef on edit.

## Changes

### Creator (`creator.ts`)
- Emit full 58-byte PARA_SHAPE records by cloning body paraShape and patching heading-specific bits.
- Write complete STYLE records with all trailing fields.
- Correct body style patch offsets for full-style format.
- Add `dloc` (column definition) control to Section0 stream.
- Set FileHeader version to Hancom-compatible byte order (`0x05010100`).

### Reader (`reader.ts`) and Mutator (`mutator.ts`)
- STYLE record parsing detects full (≥68 byte) vs legacy (<68 byte) format by record length.
- Read charShapeRef/paraShapeRef from correct offsets based on detected format.
- Prevent incorrect style references when editing Hancom-created files.

## Testing

- **Unit tests**: 620 pass / 0 fail.
- **Typecheck**: Clean.
- **Lint**: Clean.
- **Compatibility verification**: Generated test file confirmed — 58-byte paraShapes, full style records, correct header bytes, `dloc` present.
- **E2E baseline**: 211 pass / 18 fail (pre-existing, unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make HWP files generated by hwpilot open in Hancom Docs/Viewer by matching Hancom’s expected structure. Also update parsing to handle full STYLE records without breaking style references.

- Bug Fixes
  - Emit full 58-byte PARA_SHAPE records.
  - Write complete STYLE records with trailing fields (type, nextStyleId, langId, char/para refs, flags).
  - Add dloc (column definition) control to BodyText/Section0.
  - Set FileHeader version to 0x05010100 (Hancom byte order).
  - Reader/mutator detect full vs legacy STYLE formats and read refs from the correct offsets to prevent wrong charShapeRef/paraShapeRef.

<sup>Written for commit 6a13c47722bb4e1c9fd2f5fc70a2d39cb03e9f34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

