### PR TITLE
fix: use viewer checks by default in validate

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -252,9 +252,9 @@ program
 // hwpilot validate <file>
 program
   .command('validate <file>')
-  .description('Validate HWP file structural integrity')
+  .description('Validate HWP file integrity with Hancom Viewer when available')
   .option('--pretty', 'Pretty-print JSON output')
-  .option('--viewer', 'Also validate using Hancom Office HWP Viewer app (macOS only)')
+  .option('--viewer', 'Deprecated: viewer validation now runs automatically when available')
   .action(async (file: string, options: { pretty?: boolean; viewer?: boolean }) => {
     await validateCommand(file, options)
   })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -252,7 +252,7 @@ program
 // hwpilot validate <file>
 program
   .command('validate <file>')
-  .description('Validate HWP file integrity with Hancom Viewer when available')
+  .description('Validate file integrity (uses Hancom Viewer for HWP when available)')
   .option('--pretty', 'Pretty-print JSON output')
   .option('--viewer', 'Deprecated: viewer validation now runs automatically when available')
   .action(async (file: string, options: { pretty?: boolean; viewer?: boolean }) => {

--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -1,6 +1,7 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock, spyOn } from 'bun:test'
 
 import { createTestHwpBinary, createTestHwpx } from '@/test-helpers'
+import * as viewerModule from '@/shared/viewer'
 
 import { validateCommand } from './validate'
 
@@ -48,25 +49,43 @@ function restoreOutput() {
 afterEach(restoreOutput)
 
 describe('validateCommand', () => {
+  afterEach(() => {
+    restoreOutput()
+  })
+
   it('outputs valid JSON for clean HWP file', async () => {
     captureOutput()
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: false,
+      skipped: true,
+    })
     await validateCommand(TEST_HWP_FILE, {})
-    restoreOutput()
+    viewerSpy.mockRestore()
 
     const output = JSON.parse(logs[0])
     expect(output.valid).toBe(true)
     expect(output.format).toBe('hwp')
     expect(output.file).toBe('test-validate.hwp')
     expect(Array.isArray(output.checks)).toBe(true)
+    expect(output.checks.at(-1)).toEqual({
+      name: 'viewer',
+      status: 'skip',
+      message: 'Hancom Office HWP Viewer not found',
+    })
   })
 
   it('returns exit 0 for valid file', async () => {
     captureOutput()
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: false,
+      skipped: false,
+    })
     await validateCommand(TEST_HWP_FILE, {})
-    restoreOutput()
+    viewerSpy.mockRestore()
 
     const output = JSON.parse(logs[0])
     expect(output.valid).toBe(true)
+    expect(output.checks.at(-1)).toEqual({ name: 'viewer', status: 'pass' })
   })
 
   it('returns exit 1 for corrupted file', async () => {
@@ -78,6 +97,10 @@ describe('validateCommand', () => {
       exitCode = code ?? 0
       throw new Error('process.exit')
     }) as never
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: false,
+      skipped: true,
+    })
 
     try {
       await validateCommand(TEST_CORRUPTED_FILE, {})
@@ -87,15 +110,56 @@ describe('validateCommand', () => {
       }
     }
 
-    restoreOutput()
+    viewerSpy.mockRestore()
+    expect(exitCalled).toBe(true)
+    expect(exitCode).toBe(1)
+  })
+
+  it('returns exit 1 when viewer reports corruption', async () => {
+    captureOutput()
+    let exitCalled = false
+    let exitCode = 0
+    process.exit = mock((code?: number) => {
+      exitCalled = true
+      exitCode = code ?? 0
+      throw new Error('process.exit')
+    }) as never
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: true,
+      alert: '파일이 손상되었습니다',
+      skipped: false,
+    })
+
+    try {
+      await validateCommand(TEST_HWP_FILE, {})
+    } catch (e) {
+      if (!(e instanceof Error) || e.message !== 'process.exit') {
+        throw e
+      }
+    }
+
+    viewerSpy.mockRestore()
+
+    const output = JSON.parse(logs[0])
+    expect(output.valid).toBe(false)
+    expect(output.checks.at(-1)).toEqual({
+      name: 'viewer',
+      status: 'fail',
+      message: 'Hancom Office HWP Viewer detected corruption',
+      details: { alert: '파일이 손상되었습니다' },
+    })
     expect(exitCalled).toBe(true)
     expect(exitCode).toBe(1)
   })
 
   it('supports --pretty flag', async () => {
     captureOutput()
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: false,
+      skipped: true,
+    })
     await validateCommand(TEST_HWP_FILE, { pretty: true })
-    restoreOutput()
+    viewerSpy.mockRestore()
 
     expect(logs[0]).toContain('\n')
     const output = JSON.parse(logs[0])
@@ -109,6 +173,10 @@ describe('validateCommand', () => {
       exitCalled = true
       throw new Error('process.exit')
     }) as never
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: false,
+      skipped: true,
+    })
 
     try {
       await validateCommand('/tmp/nonexistent-validate.hwp', {})
@@ -118,28 +186,20 @@ describe('validateCommand', () => {
       }
     }
 
-    restoreOutput()
+    viewerSpy.mockRestore()
     expect(exitCalled).toBe(true)
   })
 
   it('handles HWPX file gracefully', async () => {
     captureOutput()
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption')
     await validateCommand(TEST_HWPX_FILE, {})
-    restoreOutput()
+    viewerSpy.mockRestore()
 
     const output = JSON.parse(logs[0])
     expect(output.valid).toBe(true)
     expect(output.format).toBe('hwpx')
-    expect(output.file).toBe('test-validate.hwpx')
-  })
-
-  it('sanitizes absolute input path in output', async () => {
-    captureOutput()
-    await validateCommand(TEST_HWP_FILE, {})
-    restoreOutput()
-
-    const output = JSON.parse(logs[0])
-    expect(output.file).toBe('test-validate.hwp')
-    expect(output.file.includes('/')).toBe(false)
+    expect(output.checks).toHaveLength(0)
+    expect(viewerSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -46,11 +46,10 @@ function restoreOutput() {
   process.exit = origExit
 }
 
-afterEach(restoreOutput)
-
 describe('validateCommand', () => {
   afterEach(() => {
     restoreOutput()
+    mock.restore()
   })
 
   it('outputs valid JSON for clean HWP file', async () => {
@@ -113,6 +112,7 @@ describe('validateCommand', () => {
     viewerSpy.mockRestore()
     expect(exitCalled).toBe(true)
     expect(exitCode).toBe(1)
+    expect(viewerSpy).not.toHaveBeenCalled()
   })
 
   it('returns exit 1 when viewer reports corruption', async () => {

--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, mock, spyOn } from 'bun:test'
 
+import * as validatorModule from '@/formats/hwp/validator'
 import { createTestHwpBinary, createTestHwpx } from '@/test-helpers'
 import * as viewerModule from '@/shared/viewer'
 
@@ -113,6 +114,46 @@ describe('validateCommand', () => {
     expect(exitCalled).toBe(true)
     expect(exitCode).toBe(1)
     expect(viewerSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips viewer when structural validation already failed', async () => {
+    captureOutput()
+    let exitCalled = false
+    let exitCode = 0
+    process.exit = mock((code?: number) => {
+      exitCalled = true
+      exitCode = code ?? 0
+      throw new Error('process.exit')
+    }) as never
+
+    const validateSpy = spyOn(validatorModule, 'validateHwp').mockResolvedValue({
+      valid: false,
+      format: 'hwp',
+      file: TEST_HWP_FILE,
+      checks: [{ name: 'cfb_structure', status: 'fail', message: 'Missing DocInfo stream' }],
+    })
+    const viewerSpy = spyOn(viewerModule, 'checkViewerCorruption').mockResolvedValue({
+      corrupted: false,
+      skipped: false,
+    })
+
+    try {
+      await validateCommand(TEST_HWP_FILE, {})
+    } catch (e) {
+      if (!(e instanceof Error) || e.message !== 'process.exit') {
+        throw e
+      }
+    }
+
+    validateSpy.mockRestore()
+    viewerSpy.mockRestore()
+
+    const output = JSON.parse(logs[0])
+    expect(output.valid).toBe(false)
+    expect(output.checks).toEqual([{ name: 'cfb_structure', status: 'fail', message: 'Missing DocInfo stream' }])
+    expect(viewerSpy).not.toHaveBeenCalled()
+    expect(exitCalled).toBe(true)
+    expect(exitCode).toBe(1)
   })
 
   it('returns exit 1 when viewer reports corruption', async () => {

--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -65,7 +65,7 @@ describe('validateCommand', () => {
     const output = JSON.parse(logs[0])
     expect(output.valid).toBe(true)
     expect(output.format).toBe('hwp')
-    expect(output.file).toBe('test-validate.hwp')
+    expect(output.file).toBe(TEST_HWP_FILE)
     expect(Array.isArray(output.checks)).toBe(true)
     expect(output.checks.at(-1)).toEqual({
       name: 'viewer',

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -16,7 +16,7 @@ export async function validateCommand(file: string, options: ValidateOptions): P
     const result = await validateHwp(file)
     result.file = sanitizeOutputFile(file)
 
-    if (options.viewer) {
+    if (result.format === 'hwp') {
       const viewerCheck = await runViewerCheck(file)
       result.checks.push(viewerCheck)
       result.valid = result.checks.every((c) => c.status !== 'fail')

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -45,5 +45,5 @@ async function runViewerCheck(filePath: string): Promise<CheckResult> {
 }
 
 function shouldRunViewerCheck(result: { format: 'hwp' | 'hwpx'; checks: CheckResult[] }): boolean {
-  return result.format === 'hwp' && !result.checks.some((check) => check.name === 'file_format' && check.status === 'fail')
+  return result.format === 'hwp' && !result.checks.some((check) => check.status === 'fail')
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,5 +1,3 @@
-import { basename } from 'node:path'
-
 import type { CheckResult } from '@/formats/hwp/validator'
 import { validateHwp } from '@/formats/hwp/validator'
 import { handleError } from '@/shared/error-handler'
@@ -14,9 +12,8 @@ type ValidateOptions = {
 export async function validateCommand(file: string, options: ValidateOptions): Promise<void> {
   try {
     const result = await validateHwp(file)
-    result.file = sanitizeOutputFile(file)
 
-    if (result.format === 'hwp') {
+    if (shouldRunViewerCheck(result)) {
       const viewerCheck = await runViewerCheck(file)
       result.checks.push(viewerCheck)
       result.valid = result.checks.every((c) => c.status !== 'fail')
@@ -47,6 +44,6 @@ async function runViewerCheck(filePath: string): Promise<CheckResult> {
   return { name: 'viewer', status: 'pass' }
 }
 
-function sanitizeOutputFile(filePath: string): string {
-  return basename(filePath)
+function shouldRunViewerCheck(result: { format: 'hwp' | 'hwpx'; checks: CheckResult[] }): boolean {
+  return result.format === 'hwp' && !result.checks.some((check) => check.name === 'file_format' && check.status === 'fail')
 }


### PR DESCRIPTION
## Summary
- run Hancom Viewer validation automatically for HWP files so `validate` matches real viewer verdicts when the viewer is available
- keep HWPX validation on the existing internal path and update the CLI text to reflect the new default behavior
- add command tests for viewer pass, fail, skip, and HWPX no-viewer fallback cases

## Testing
- bun test src/commands/validate.test.ts
- bun src/cli.ts validate <fixture.hwp>