### PR TITLE
fix: sanitize validate file output

### DIFF
--- a/src/commands/validate.test.ts
+++ b/src/commands/validate.test.ts
@@ -56,7 +56,7 @@ describe('validateCommand', () => {
     const output = JSON.parse(logs[0])
     expect(output.valid).toBe(true)
     expect(output.format).toBe('hwp')
-    expect(output.file).toBe(TEST_HWP_FILE)
+    expect(output.file).toBe('test-validate.hwp')
     expect(Array.isArray(output.checks)).toBe(true)
   })
 
@@ -130,5 +130,16 @@ describe('validateCommand', () => {
     const output = JSON.parse(logs[0])
     expect(output.valid).toBe(true)
     expect(output.format).toBe('hwpx')
+    expect(output.file).toBe('test-validate.hwpx')
+  })
+
+  it('sanitizes absolute input path in output', async () => {
+    captureOutput()
+    await validateCommand(TEST_HWP_FILE, {})
+    restoreOutput()
+
+    const output = JSON.parse(logs[0])
+    expect(output.file).toBe('test-validate.hwp')
+    expect(output.file.includes('/')).toBe(false)
   })
 })

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,3 +1,5 @@
+import { basename } from 'node:path'
+
 import type { CheckResult } from '@/formats/hwp/validator'
 import { validateHwp } from '@/formats/hwp/validator'
 import { handleError } from '@/shared/error-handler'
@@ -12,6 +14,7 @@ type ValidateOptions = {
 export async function validateCommand(file: string, options: ValidateOptions): Promise<void> {
   try {
     const result = await validateHwp(file)
+    result.file = sanitizeOutputFile(file)
 
     if (options.viewer) {
       const viewerCheck = await runViewerCheck(file)
@@ -42,4 +45,8 @@ async function runViewerCheck(filePath: string): Promise<CheckResult> {
     }
   }
   return { name: 'viewer', status: 'pass' }
+}
+
+function sanitizeOutputFile(filePath: string): string {
+  return basename(filePath)
 }


### PR DESCRIPTION
## Summary
- sanitize the `validate` command's `file` field so it returns only the basename instead of exposing absolute local paths
- update validate command tests to cover sanitized HWP and HWPX output plus a regression case that asserts the output contains no path separators

## Testing
- bun test src/commands/validate.test.ts
- bun src/cli.ts validate <fixture.hwp> --viewer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize the `validate` command output: the `file` field now includes only the basename, not the absolute path. This prevents leaking local paths in JSON output.

- **Bug Fixes**
  - Use `basename` from `node:path` to set `result.file`.
  - Updated tests for HWP/HWPX and added a regression check to ensure no path separators.

<sup>Written for commit 515ab49fa72e3b41e791a84d47791b833fb08425. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

