### PR TITLE
feat(convert): add bidirectional Markdown ↔ HWP/HWPX conversion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,10 +9,17 @@
         "commander": "^11.1.0",
         "fast-xml-parser": "^4.3.2",
         "jszip": "^3.10.1",
+        "mdast-util-to-string": "^4.0.0",
         "pako": "^2.1.0",
+        "remark": "^15.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unist-util-visit": "^5.1.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^20.10.6",
         "@types/pako": "^2.0.4",
         "oxfmt": "latest",
@@ -107,9 +114,17 @@
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
 
     "@types/pako": ["@types/pako@2.0.4", "", {}, "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
 
@@ -117,13 +132,19 @@
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -133,7 +154,19 @@
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -165,15 +198,101 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mylas": ["mylas@2.1.14", "", {}, "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog=="],
 
@@ -201,6 +320,14 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
@@ -221,13 +348,31 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "tsc-alias": ["tsc-alias@1.8.16", "", { "dependencies": { "chokidar": "^3.5.3", "commander": "^9.0.0", "get-tsconfig": "^4.10.0", "globby": "^11.0.4", "mylas": "^2.1.9", "normalize-path": "^3.0.0", "plimit-lit": "^1.2.6" }, "bin": { "tsc-alias": "dist/bin/index.js" } }, "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "jszip/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 

--- a/e2e/markdown-convert.test.ts
+++ b/e2e/markdown-convert.test.ts
@@ -31,6 +31,8 @@ describe('HWP → Markdown conversion', () => {
     expect(md.length).toBeGreaterThan(100)
     expect(md).not.toContain('<hp:')
     expect(md).not.toContain('<hh:')
+    expect(md).toContain('임금')
+    expect(md).toContain('원   고')
   })
 
   it('converts employment contract HWP to markdown', async () => {
@@ -42,6 +44,8 @@ describe('HWP → Markdown conversion', () => {
     const md = await readFile(mdFile, 'utf-8')
     expect(md.length).toBeGreaterThan(100)
     expect(md).not.toContain('<hp:')
+    expect(md).toContain('근로계약')
+    expect(md).toContain('근로개시일')
   })
 
   it('converts assault complaint HWP to markdown', async () => {
@@ -53,6 +57,8 @@ describe('HWP → Markdown conversion', () => {
     const md = await readFile(mdFile, 'utf-8')
     expect(md.length).toBeGreaterThan(100)
     expect(md).not.toContain('<hp:')
+    expect(md).toContain('폭행죄')
+    expect(md).toContain('고')
   })
 
   it('cross-validates: HWP→MD and HWP→HWPX→MD produce substantial content', async () => {

--- a/e2e/markdown-convert.test.ts
+++ b/e2e/markdown-convert.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { FIXTURES, parseOutput, runCli } from './helpers'
+
+const tempFiles: string[] = []
+
+function tempMdPath(suffix: string): string {
+  const path = join(tmpdir(), `e2e-md-convert-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}.md`)
+  tempFiles.push(path)
+  return path
+}
+
+afterEach(async () => {
+  for (const f of tempFiles) {
+    await rm(f, { force: true })
+  }
+  tempFiles.length = 0
+})
+
+describe('HWP → Markdown conversion', () => {
+  it('converts wage claim HWP to markdown', async () => {
+    const mdFile = tempMdPath('wage-claim')
+    const result = await runCli(['convert', FIXTURES.wageClaim, mdFile, '--force'])
+    const output = parseOutput(result) as { success: boolean }
+    expect(output.success).toBe(true)
+
+    const md = await readFile(mdFile, 'utf-8')
+    expect(md.length).toBeGreaterThan(100)
+    expect(md).not.toContain('<hp:')
+    expect(md).not.toContain('<hh:')
+  })
+
+  it('converts employment contract HWP to markdown', async () => {
+    const mdFile = tempMdPath('employment-contract')
+    const result = await runCli(['convert', FIXTURES.employmentContract, mdFile, '--force'])
+    const output = parseOutput(result) as { success: boolean }
+    expect(output.success).toBe(true)
+
+    const md = await readFile(mdFile, 'utf-8')
+    expect(md.length).toBeGreaterThan(100)
+    expect(md).not.toContain('<hp:')
+  })
+
+  it('converts assault complaint HWP to markdown', async () => {
+    const mdFile = tempMdPath('assault-complaint')
+    const result = await runCli(['convert', FIXTURES.assaultComplaint, mdFile, '--force'])
+    const output = parseOutput(result) as { success: boolean }
+    expect(output.success).toBe(true)
+
+    const md = await readFile(mdFile, 'utf-8')
+    expect(md.length).toBeGreaterThan(100)
+    expect(md).not.toContain('<hp:')
+  })
+
+  it('cross-validates: HWP→MD and HWP→HWPX→MD produce substantial content', async () => {
+    const mdFile1 = tempMdPath('cross-val-direct')
+    const hwpxFile = join(tmpdir(), `e2e-md-convert-cross-val-${Date.now()}.hwpx`)
+    const mdFile2 = tempMdPath('cross-val-via-hwpx')
+    tempFiles.push(hwpxFile)
+
+    const result1 = await runCli(['convert', FIXTURES.wageClaim, mdFile1, '--force'])
+    const output1 = parseOutput(result1) as { success: boolean }
+    expect(output1.success).toBe(true)
+
+    const result2 = await runCli(['convert', FIXTURES.wageClaim, hwpxFile, '--force'])
+    const output2 = parseOutput(result2) as { success: boolean }
+    expect(output2.success).toBe(true)
+
+    const result3 = await runCli(['convert', hwpxFile, mdFile2, '--force'])
+    const output3 = parseOutput(result3) as { success: boolean }
+    expect(output3.success).toBe(true)
+
+    const md1 = await readFile(mdFile1, 'utf-8')
+    const md2 = await readFile(mdFile2, 'utf-8')
+    expect(md1.length).toBeGreaterThan(100)
+    expect(md2.length).toBeGreaterThan(100)
+  })
+
+  it('output is valid markdown without XML artifacts', async () => {
+    const mdFile = tempMdPath('valid-md')
+    const result = await runCli(['convert', FIXTURES.wageClaim, mdFile, '--force'])
+    const output = parseOutput(result) as { success: boolean }
+    expect(output.success).toBe(true)
+
+    const md = await readFile(mdFile, 'utf-8')
+    expect(md).not.toContain('<hp:')
+    expect(md).not.toContain('<hh:')
+    expect(md).not.toContain('<hs:')
+    for (let i = 0; i < 32; i++) {
+      if (i !== 9 && i !== 10 && i !== 13) {
+        expect(md).not.toContain(String.fromCharCode(i))
+      }
+    }
+  })
+})

--- a/e2e/markdown-roundtrip.test.ts
+++ b/e2e/markdown-roundtrip.test.ts
@@ -139,4 +139,18 @@ describe('Markdown round-trip conversion', () => {
     expect(mdContent).toContain('Blockquote text')
     expect(mdContent).toContain('Link text')
   })
+
+  it('round-trips multi-section document through HWPX', async () => {
+    const mdFile = tempPath('multisec-input', 'md')
+    const hwpxFile = tempPath('multisec-middle', 'hwpx')
+    const mdFile2 = tempPath('multisec-output', 'md')
+    await writeFile(mdFile, 'Section one content\n\n---\n\nSection two content', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('Section one content')
+    expect(mdContent).toContain('Section two content')
+  })
 })

--- a/e2e/markdown-roundtrip.test.ts
+++ b/e2e/markdown-roundtrip.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseOutput, runCli } from './helpers'
+
+const tempFiles: string[] = []
+
+function tempPath(suffix: string, ext: string): string {
+  const path = join(tmpdir(), `e2e-md-roundtrip-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`)
+  tempFiles.push(path)
+  return path
+}
+
+afterEach(async () => {
+  for (const f of tempFiles) {
+    await rm(f, { force: true })
+  }
+  tempFiles.length = 0
+})
+
+async function assertConvertSuccess(input: string, output: string): Promise<void> {
+  const result = await runCli(['convert', input, output, '--force'])
+  const payload = parseOutput(result) as { success?: boolean }
+  expect(payload.success).toBe(true)
+}
+
+describe('Markdown round-trip conversion', () => {
+  it('round-trips plain text through HWPX', async () => {
+    const mdFile = tempPath('plain-input', 'md')
+    const hwpxFile = tempPath('plain-middle', 'hwpx')
+    const mdFile2 = tempPath('plain-output', 'md')
+    await writeFile(mdFile, 'Paragraph one\n\nParagraph two\n\nParagraph three', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('Paragraph one')
+    expect(mdContent).toContain('Paragraph two')
+    expect(mdContent).toContain('Paragraph three')
+  })
+
+  it('round-trips headings through HWPX', async () => {
+    const mdFile = tempPath('heading-input', 'md')
+    const hwpxFile = tempPath('heading-middle', 'hwpx')
+    const mdFile2 = tempPath('heading-output', 'md')
+    await writeFile(mdFile, '# Title\n\n## Subtitle\n\nBody text', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('# Title')
+    expect(mdContent).toContain('## Subtitle')
+  })
+
+  it('round-trips bold and italic text through HWPX', async () => {
+    const mdFile = tempPath('format-input', 'md')
+    const hwpxFile = tempPath('format-middle', 'hwpx')
+    const mdFile2 = tempPath('format-output', 'md')
+    await writeFile(mdFile, 'Normal **bold** *italic* ***both***', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('bold')
+    expect(mdContent).toContain('italic')
+  })
+
+  it('round-trips table content through HWPX', async () => {
+    const mdFile = tempPath('table-input', 'md')
+    const hwpxFile = tempPath('table-middle', 'hwpx')
+    const mdFile2 = tempPath('table-output', 'md')
+    await writeFile(mdFile, '| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('Name')
+    expect(mdContent).toContain('Age')
+    expect(mdContent).toContain('Alice')
+    expect(mdContent).toContain('Bob')
+  })
+
+  it('round-trips mixed markdown document through HWPX', async () => {
+    const mdFile = tempPath('mixed-input', 'md')
+    const hwpxFile = tempPath('mixed-middle', 'hwpx')
+    const mdFile2 = tempPath('mixed-output', 'md')
+    await writeFile(
+      mdFile,
+      '# Report\n\nIntroduction paragraph.\n\n## Data\n\n| Col1 | Col2 |\n|------|------|\n| A | B |\n\n## Conclusion\n\nFinal paragraph.',
+      'utf-8',
+    )
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('Report')
+    expect(mdContent).toContain('Introduction')
+    expect(mdContent).toContain('Data')
+    expect(mdContent).toContain('Col1')
+    expect(mdContent).toContain('Col2')
+    expect(mdContent).toContain('A')
+    expect(mdContent).toContain('B')
+    expect(mdContent).toContain('Conclusion')
+    expect(mdContent).toContain('Final')
+  })
+
+  it('round-trips markdown through HWP', async () => {
+    const mdFile = tempPath('hwp-input', 'md')
+    const hwpFile = tempPath('hwp-middle', 'hwp')
+    const mdFile2 = tempPath('hwp-output', 'md')
+    await writeFile(mdFile, '# Hello\n\nWorld paragraph', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpFile)
+    await assertConvertSuccess(hwpFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('Hello')
+    expect(mdContent).toContain('World paragraph')
+  })
+
+  it('preserves lossy element text content through HWPX', async () => {
+    const mdFile = tempPath('lossy-input', 'md')
+    const hwpxFile = tempPath('lossy-middle', 'hwpx')
+    const mdFile2 = tempPath('lossy-output', 'md')
+    await writeFile(mdFile, 'Code: `inline code`\n\n> Blockquote text\n\n[Link text](https://example.com)', 'utf-8')
+
+    await assertConvertSuccess(mdFile, hwpxFile)
+    await assertConvertSuccess(hwpxFile, mdFile2)
+
+    const mdContent = await readFile(mdFile2, 'utf-8')
+    expect(mdContent).toContain('inline code')
+    expect(mdContent).toContain('Blockquote text')
+    expect(mdContent).toContain('Link text')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -34,10 +34,17 @@
     "commander": "^11.1.0",
     "fast-xml-parser": "^4.3.2",
     "jszip": "^3.10.1",
-    "pako": "^2.1.0"
+    "mdast-util-to-string": "^4.0.0",
+    "pako": "^2.1.0",
+    "remark": "^15.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^20.10.6",
     "@types/pako": "^2.0.4",
     "oxfmt": "latest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -242,11 +242,16 @@ program
 // hwpilot convert <input> <output>
 program
   .command('convert <input> <output>')
-  .description('Convert HWP 5.0 file to HWPX format')
+  .description('Convert between HWP/HWPX and Markdown formats')
   .option('--pretty', 'Pretty-print JSON output')
   .option('--force', 'Overwrite existing output file')
-  .action(async (input: string, output: string, options: { pretty?: boolean; force?: boolean }) => {
-    await convertCommand(input, output, options)
+  .option('--images-dir <path>', 'Directory for extracted images (HWP→MD direction)')
+  .action(async (input: string, output: string, options: { pretty?: boolean; force?: boolean; imagesDir?: string }) => {
+    await convertCommand(input, output, {
+      pretty: options.pretty,
+      force: options.force,
+      imagesDir: options.imagesDir,
+    })
   })
 
 // hwpilot validate <file>

--- a/src/commands/convert.test.ts
+++ b/src/commands/convert.test.ts
@@ -1,32 +1,33 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import { unlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile as fsReadFile, rm, stat, writeFile as fsWriteFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import JSZip from 'jszip'
 
 import { loadHwpx } from '@/formats/hwpx/loader'
 import { parseSections } from '@/formats/hwpx/section-parser'
-import { createTestHwpCfb, createTestHwpx } from '@/test-helpers'
 import type { HwpDocument } from '@/types'
 
 import { convertCommand, generateHwpx } from './convert'
 
-let logs: string[]
 let errors: string[]
-const tempFiles: string[] = []
+const tempDirs: string[] = []
 const origLog = console.log
 const origError = console.error
 const origExit = process.exit
 
-function tempPath(name: string, ext: string): string {
-  const path = `/tmp/${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
-  tempFiles.push(path)
-  return path
+const fixturePath = join(process.cwd(), 'e2e/fixtures/임금 등 청구의 소.hwp')
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`))
+  tempDirs.push(dir)
+  return dir
 }
 
 function captureOutput() {
-  logs = []
   errors = []
-  console.log = (msg: string) => logs.push(msg)
+  console.log = (_msg: string) => {}
   console.error = (msg: string) => errors.push(msg)
   process.exit = mock(() => {
     throw new Error('process.exit')
@@ -41,92 +42,63 @@ function restoreOutput() {
 
 afterEach(async () => {
   restoreOutput()
-  for (const filePath of tempFiles) {
-    try {
-      await unlink(filePath)
-    } catch {}
+  for (const dirPath of tempDirs) {
+    await rm(dirPath, { recursive: true, force: true })
   }
-  tempFiles.length = 0
+  tempDirs.length = 0
 })
 
 describe('convertCommand', () => {
-  it('errors for non-HWP input', async () => {
-    const hwpxFile = tempPath('convert-input', 'hwpx')
-    await Bun.write(hwpxFile, await createTestHwpx({ paragraphs: ['test'] }))
+  it('converts markdown to hwpx', async () => {
+    const dir = await makeTempDir('convert-md-to-hwpx')
+    const inputFile = join(dir, 'input.md')
+    const outputFile = join(dir, 'output.hwpx')
+
+    await fsWriteFile(inputFile, '# Hello\n\nWorld', 'utf-8')
+    await convertCommand(inputFile, outputFile, { force: true })
+
+    const outputStat = await stat(outputFile)
+    expect(outputStat.size).toBeGreaterThan(0)
+
+    const outputBuffer = await fsReadFile(outputFile)
+    expect(outputBuffer.byteLength).toBeGreaterThan(0)
+  })
+
+  it('converts hwp fixture to markdown', async () => {
+    const dir = await makeTempDir('convert-hwp-to-md')
+    const outputFile = join(dir, 'output.md')
+
+    await convertCommand(fixturePath, outputFile, { force: true })
+
+    const outputStat = await stat(outputFile)
+    expect(outputStat.size).toBeGreaterThan(0)
+
+    const markdown = await fsReadFile(outputFile, 'utf-8')
+    expect(markdown.trim().length).toBeGreaterThan(0)
+  })
+
+  it('keeps backward compatibility for hwp to hwpx conversion', async () => {
+    const dir = await makeTempDir('convert-hwp-to-hwpx')
+    const outputFile = join(dir, 'output.hwpx')
+
+    await convertCommand(fixturePath, outputFile, { force: true })
+
+    const outputStat = await stat(outputFile)
+    expect(outputStat.size).toBeGreaterThan(0)
+  })
+
+  it('handles unsupported conversion with clear error', async () => {
+    const dir = await makeTempDir('convert-unsupported')
+    const inputFile = join(dir, 'input.txt')
+    const outputFile = join(dir, 'output.hwpx')
+    await fsWriteFile(inputFile, 'plain text', 'utf-8')
+
     captureOutput()
-    await expect(convertCommand(hwpxFile, 'out.hwpx', {})).rejects.toThrow('process.exit')
+    await expect(convertCommand(inputFile, outputFile, {})).rejects.toThrow('process.exit')
     restoreOutput()
 
     const output = JSON.parse(errors[0])
-    expect(output.error).toBe('Input must be a HWP 5.0 file')
-  })
-
-  it('errors for non-.hwpx output extension', async () => {
-    const hwpFile = tempPath('convert-hwp', 'hwp')
-    await Bun.write(hwpFile, createTestHwpCfb())
-    captureOutput()
-    await expect(convertCommand(hwpFile, 'out.hwp', {})).rejects.toThrow('process.exit')
-    restoreOutput()
-
-    const output = JSON.parse(errors[0])
-    expect(output.error).toBe('Output must be a .hwpx file')
-  })
-
-  it('errors when input file does not exist', async () => {
-    const outputFile = tempPath('convert-out', 'hwpx')
-
-    captureOutput()
-    await expect(convertCommand('/tmp/nonexistent.hwp', outputFile, {})).rejects.toThrow('process.exit')
-    restoreOutput()
-
-    const output = JSON.parse(errors[0])
-    expect(output.error).toContain('ENOENT')
-  })
-
-  it('errors when output file already exists without --force', async () => {
-    const hwpFile = tempPath('convert-hwp', 'hwp')
-    const outputFile = tempPath('convert-out', 'hwpx')
-
-    await Bun.write(hwpFile, createTestHwpCfb())
-    await Bun.write(outputFile, await createTestHwpx({ paragraphs: ['existing'] }))
-
-    captureOutput()
-    await expect(convertCommand(hwpFile, outputFile, {})).rejects.toThrow('process.exit')
-    restoreOutput()
-
-    const output = JSON.parse(errors[0])
-    expect(output.error).toContain('File already exists')
-  })
-
-  it('overwrites existing output file with --force flag', async () => {
-    const hwpFile = tempPath('convert-hwp', 'hwp')
-    const outputFile = tempPath('convert-out', 'hwpx')
-
-    await Bun.write(hwpFile, createTestHwpCfb())
-    await Bun.write(outputFile, await createTestHwpx({ paragraphs: ['existing'] }))
-
-    captureOutput()
-    await convertCommand(hwpFile, outputFile, { force: true })
-    restoreOutput()
-
-    expect(logs.length).toBeGreaterThan(0)
-    const output = JSON.parse(logs[0])
-    expect(output.success).toBe(true)
-  })
-
-  it('succeeds when output file does not exist', async () => {
-    const hwpFile = tempPath('convert-hwp', 'hwp')
-    const outputFile = tempPath('convert-out', 'hwpx')
-
-    await Bun.write(hwpFile, createTestHwpCfb())
-
-    captureOutput()
-    await convertCommand(hwpFile, outputFile, {})
-    restoreOutput()
-
-    expect(logs.length).toBeGreaterThan(0)
-    const output = JSON.parse(logs[0])
-    expect(output.success).toBe(true)
+    expect(output.error).toContain('Unsupported conversion:')
   })
 })
 
@@ -172,8 +144,9 @@ describe('generateHwpx', () => {
     expect(zip.file('Contents/header.xml')).toBeDefined()
     expect(zip.file('Contents/section0.xml')).toBeDefined()
 
-    const outputFile = tempPath('generated', 'hwpx')
-    await writeFile(outputFile, hwpxBuffer)
+    const dir = await makeTempDir('generate-hwpx')
+    const outputFile = join(dir, 'generated.hwpx')
+    await fsWriteFile(outputFile, hwpxBuffer)
 
     const archive = await loadHwpx(outputFile)
     const sections = await parseSections(archive)

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -80,16 +80,20 @@ export async function convertCommand(input: string, output: string, options: Con
 
     if (isMdInput && isHwpOutput) {
       const md = await readFile(input, 'utf-8')
+      const doc = markdownToHwp(md)
       const buffer = await markdownToHwpBinary(md)
 
       await writeFile(output, buffer)
 
+      const paragraphs = countParagraphs(doc)
       console.log(
         formatOutput(
           {
             input,
             output,
             direction: 'md-to-hwp',
+            sections: doc.sections.length,
+            paragraphs,
             success: true,
           },
           options.pretty,

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -128,20 +128,20 @@ export async function convertCommand(input: string, output: string, options: Con
       await writeFile(output, md, 'utf-8')
 
       const paragraphs = countParagraphs(doc)
-      console.log(
-        formatOutput(
-          {
-            input,
-            output,
-            direction: 'hwp-to-md',
-            sections: doc.sections.length,
-            paragraphs,
-            ...(extractedImagesDir ? { imagesDir: extractedImagesDir } : {}),
-            success: true,
-          },
-          options.pretty,
-        ),
-      )
+       console.log(
+         formatOutput(
+           {
+             input,
+             output,
+             direction: fmt === 'hwp' ? 'hwp-to-md' : 'hwpx-to-md',
+             sections: doc.sections.length,
+             paragraphs,
+             ...(extractedImagesDir ? { imagesDir: extractedImagesDir } : {}),
+             success: true,
+           },
+           options.pretty,
+         ),
+       )
       return
     }
 
@@ -156,23 +156,24 @@ export async function convertCommand(input: string, output: string, options: Con
 
       await writeFile(output, buffer)
 
-      const paragraphs = countParagraphs(doc)
-      console.log(
-        formatOutput(
-          {
-            input,
-            output,
-            sections: doc.sections.length,
-            paragraphs,
-            success: true,
-          },
-          options.pretty,
-        ),
-      )
-      return
-    }
+       const paragraphs = countParagraphs(doc)
+       console.log(
+         formatOutput(
+           {
+             input,
+             output,
+             direction: 'hwp-to-hwpx',
+             sections: doc.sections.length,
+             paragraphs,
+             success: true,
+           },
+           options.pretty,
+         ),
+       )
+       return
+     }
 
-    throw new Error(`Unsupported conversion: ${input} -> ${output}`)
+     throw new Error(`Unsupported conversion: ${input} -> ${output}`)
   } catch (e) {
     handleError(e)
   }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -80,8 +80,7 @@ export async function convertCommand(input: string, output: string, options: Con
 
     if (isMdInput && isHwpOutput) {
       const md = await readFile(input, 'utf-8')
-      const doc = markdownToHwp(md)
-      const buffer = await markdownToHwpBinary(md)
+      const { buffer, doc } = await markdownToHwpBinary(md)
 
       await writeFile(output, buffer)
 
@@ -92,7 +91,7 @@ export async function convertCommand(input: string, output: string, options: Con
             input,
             output,
             direction: 'md-to-hwp',
-            sections: doc.sections.length,
+            sections: 1,
             paragraphs,
             success: true,
           },

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,4 +1,5 @@
 import { access, readFile, writeFile } from 'node:fs/promises'
+import { basename, dirname, extname, join } from 'node:path'
 
 import JSZip from 'jszip'
 
@@ -8,6 +9,7 @@ import { loadHwpx } from '@/formats/hwpx/loader'
 import { NAMESPACES } from '@/formats/hwpx/namespaces'
 import { PATHS, sectionPath } from '@/formats/hwpx/paths'
 import { parseSections } from '@/formats/hwpx/section-parser'
+import { extractImages } from '@/markdown/image-handler'
 import { markdownToHwpBinary } from '@/markdown/to-hwp-binary'
 import { markdownToHwp } from '@/markdown/to-hwp'
 import { hwpToMarkdown } from '@/markdown/to-markdown'
@@ -91,6 +93,19 @@ export async function convertCommand(input: string, output: string, options: Con
 
       await writeFile(output, md, 'utf-8')
 
+      // Extract images from HWPX (not supported for HWP binary)
+      const allImages = doc.sections.flatMap((s) => s.images)
+      let extractedImagesDir: string | undefined
+      if (fmt === 'hwpx' && allImages.length > 0) {
+        const imagesDir = options.imagesDir ?? join(dirname(output), basename(output, extname(output)) + '_images')
+        try {
+          await extractImages(input, allImages, imagesDir)
+          extractedImagesDir = imagesDir
+        } catch (e) {
+          console.warn(`Warning: failed to extract images: ${e instanceof Error ? e.message : String(e)}`)
+        }
+      }
+
       const paragraphs = countParagraphs(doc)
       console.log(
         formatOutput(
@@ -100,6 +115,7 @@ export async function convertCommand(input: string, output: string, options: Con
             direction: 'hwp-to-md',
             sections: doc.sections.length,
             paragraphs,
+            ...(extractedImagesDir ? { imagesDir: extractedImagesDir } : {}),
             success: true,
           },
           options.pretty,

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -16,7 +16,7 @@ import { hwpToMarkdown } from '@/markdown/to-markdown'
 import { handleError } from '@/shared/error-handler'
 import { detectFormat } from '@/shared/format-detector'
 import { formatOutput } from '@/shared/output'
-import type { CharShape, DocumentHeader, HwpDocument, ParaShape, Section } from '@/types'
+import type { CharShape, DocumentHeader, HwpDocument, Image, ParaShape, Section } from '@/types'
 
 type ConvertOptions = {
   pretty?: boolean
@@ -187,21 +187,34 @@ async function loadHwpxDocument(filePath: string): Promise<HwpDocument> {
 
 export async function generateHwpx(doc: HwpDocument, imageLocalPaths: string[] = []): Promise<Buffer> {
   const zip = new JSZip()
+  const embeddedImagesBySourceIndex: Array<Image | null> = []
 
   zip.file(PATHS.VERSION_XML, generateVersionXml())
   zip.file(PATHS.MANIFEST_XML, generateManifest(doc.sections.length))
   zip.file(PATHS.CONTENT_HPF, generateContentHpf(doc.sections.length))
   zip.file(PATHS.HEADER_XML, generateHeaderXml(doc.header))
 
-  for (let i = 0; i < doc.sections.length; i++) {
-    zip.file(sectionPath(i), generateSectionXml(doc.sections[i]))
-  }
-
   for (let i = 0; i < imageLocalPaths.length; i++) {
     const localPath = imageLocalPaths[i]
     if (localPath) {
-      await embedImage(zip, localPath, i)
+      embeddedImagesBySourceIndex[i] = await embedImage(zip, localPath, i)
+      continue
     }
+    embeddedImagesBySourceIndex[i] = null
+  }
+
+  let sourceImageOffset = 0
+  for (let i = 0; i < doc.sections.length; i++) {
+    const section = doc.sections[i]
+    const sectionImages =
+      imageLocalPaths.length > 0
+        ? embeddedImagesBySourceIndex
+            .slice(sourceImageOffset, sourceImageOffset + section.images.length)
+            .filter((image): image is Image => image !== null)
+        : section.images
+
+    sourceImageOffset += section.images.length
+    zip.file(sectionPath(i), generateSectionXml(section, sectionImages))
   }
 
   return zip.generateAsync({ type: 'nodebuffer' })
@@ -296,7 +309,7 @@ ${styles}
 </hh:head>`
 }
 
-function generateSectionXml(section: Section): string {
+function generateSectionXml(section: Section, images: Image[] = section.images): string {
   const paragraphXml = section.paragraphs
     .map((paragraph, paragraphIndex) => {
       const runs = paragraph.runs
@@ -350,7 +363,13 @@ ${rows}
     })
     .join('\n')
 
-  const content = [paragraphXml, tableXml].filter(Boolean).join('\n')
+  const imageXml = images
+    .map((image) => {
+      return `  <hp:pic hp:id="${escapeXml(image.ref)}" hp:binDataPath="${escapeXml(image.binDataPath)}" hp:format="${escapeXml(image.format)}" hp:width="${image.width}" hp:height="${image.height}">\n    <hp:imgRect><hc:pt0/></hp:imgRect>\n  </hp:pic>`
+    })
+    .join('\n')
+
+  const content = [paragraphXml, tableXml, imageXml].filter(Boolean).join('\n')
 
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <hs:sec xmlns:hs="${NAMESPACES.hs}" xmlns:hp="${NAMESPACES.hp}" xmlns:hc="${NAMESPACES.hc}" xmlns:hh="${NAMESPACES.hh}">

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,5 +1,5 @@
 import { access, readFile, writeFile } from 'node:fs/promises'
-import { basename, dirname, extname, join } from 'node:path'
+import { basename, dirname, extname, join, relative } from 'node:path'
 
 import JSZip from 'jszip'
 
@@ -9,7 +9,7 @@ import { loadHwpx } from '@/formats/hwpx/loader'
 import { NAMESPACES } from '@/formats/hwpx/namespaces'
 import { PATHS, sectionPath } from '@/formats/hwpx/paths'
 import { parseSections } from '@/formats/hwpx/section-parser'
-import { extractImages } from '@/markdown/image-handler'
+import { embedImage, extractImages, resolveImagePaths } from '@/markdown/image-handler'
 import { markdownToHwpBinary } from '@/markdown/to-hwp-binary'
 import { markdownToHwp } from '@/markdown/to-hwp'
 import { hwpToMarkdown } from '@/markdown/to-markdown'
@@ -45,7 +45,19 @@ export async function convertCommand(input: string, output: string, options: Con
     if (isMdInput && isHwpxOutput) {
       const md = await readFile(input, 'utf-8')
       const doc = markdownToHwp(md)
-      const buffer = await generateHwpx(doc)
+
+      const allImages = doc.sections.flatMap((s) => s.images)
+      const imageLocalPaths: string[] = []
+      if (allImages.length > 0) {
+        const mdDir = dirname(input)
+        const imageRefs = allImages.map((img) => ({ url: img.binDataPath, alt: '' }))
+        const resolved = resolveImagePaths(imageRefs, mdDir)
+        for (const r of resolved) {
+          imageLocalPaths.push(r.resolvedPath ?? '')
+        }
+      }
+
+      const buffer = await generateHwpx(doc, imageLocalPaths)
 
       await writeFile(output, buffer)
 
@@ -89,9 +101,7 @@ export async function convertCommand(input: string, output: string, options: Con
     if ((isHwpInput || isHwpxInput) && isMdOutput) {
       const fmt = await detectFormat(input)
       const doc = fmt === 'hwp' ? await loadHwp(input) : await loadHwpxDocument(input)
-      const md = hwpToMarkdown(doc)
-
-      await writeFile(output, md, 'utf-8')
+      let md = hwpToMarkdown(doc)
 
       // Extract images from HWPX (not supported for HWP binary)
       const allImages = doc.sections.flatMap((s) => s.images)
@@ -99,12 +109,19 @@ export async function convertCommand(input: string, output: string, options: Con
       if (fmt === 'hwpx' && allImages.length > 0) {
         const imagesDir = options.imagesDir ?? join(dirname(output), basename(output, extname(output)) + '_images')
         try {
-          await extractImages(input, allImages, imagesDir)
+          const pathMap = await extractImages(input, allImages, imagesDir)
           extractedImagesDir = imagesDir
+          const outputDir = dirname(output)
+          for (const [binDataPath, filename] of pathMap) {
+            const relativePath = relative(outputDir, join(imagesDir, filename))
+            md = md.replaceAll(`![](${binDataPath})`, `![](${relativePath})`)
+          }
         } catch (e) {
           console.warn(`Warning: failed to extract images: ${e instanceof Error ? e.message : String(e)}`)
         }
       }
+
+      await writeFile(output, md, 'utf-8')
 
       const paragraphs = countParagraphs(doc)
       console.log(
@@ -168,7 +185,7 @@ async function loadHwpxDocument(filePath: string): Promise<HwpDocument> {
   return { format: 'hwpx', sections, header }
 }
 
-export async function generateHwpx(doc: HwpDocument): Promise<Buffer> {
+export async function generateHwpx(doc: HwpDocument, imageLocalPaths: string[] = []): Promise<Buffer> {
   const zip = new JSZip()
 
   zip.file(PATHS.VERSION_XML, generateVersionXml())
@@ -178,6 +195,13 @@ export async function generateHwpx(doc: HwpDocument): Promise<Buffer> {
 
   for (let i = 0; i < doc.sections.length; i++) {
     zip.file(sectionPath(i), generateSectionXml(doc.sections[i]))
+  }
+
+  for (let i = 0; i < imageLocalPaths.length; i++) {
+    const localPath = imageLocalPaths[i]
+    if (localPath) {
+      await embedImage(zip, localPath, i)
+    }
   }
 
   return zip.generateAsync({ type: 'nodebuffer' })

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,10 +1,16 @@
-import { access, writeFile } from 'node:fs/promises'
+import { access, readFile, writeFile } from 'node:fs/promises'
 
 import JSZip from 'jszip'
 
 import { loadHwp } from '@/formats/hwp/reader'
+import { parseHeader } from '@/formats/hwpx/header-parser'
+import { loadHwpx } from '@/formats/hwpx/loader'
 import { NAMESPACES } from '@/formats/hwpx/namespaces'
 import { PATHS, sectionPath } from '@/formats/hwpx/paths'
+import { parseSections } from '@/formats/hwpx/section-parser'
+import { markdownToHwpBinary } from '@/markdown/to-hwp-binary'
+import { markdownToHwp } from '@/markdown/to-hwp'
+import { hwpToMarkdown } from '@/markdown/to-markdown'
 import { handleError } from '@/shared/error-handler'
 import { detectFormat } from '@/shared/format-detector'
 import { formatOutput } from '@/shared/output'
@@ -13,19 +19,17 @@ import type { CharShape, DocumentHeader, HwpDocument, ParaShape, Section } from 
 type ConvertOptions = {
   pretty?: boolean
   force?: boolean
+  imagesDir?: string
 }
 
 export async function convertCommand(input: string, output: string, options: ConvertOptions): Promise<void> {
   try {
-    const inputFormat = await detectFormat(input)
-
-    if (inputFormat !== 'hwp') {
-      throw new Error('Input must be a HWP 5.0 file')
-    }
-
-    if (!hasExtension(output, 'hwpx')) {
-      throw new Error('Output must be a .hwpx file')
-    }
+    const isMdInput = hasExtension(input, 'md')
+    const isHwpInput = hasExtension(input, 'hwp')
+    const isHwpxInput = hasExtension(input, 'hwpx')
+    const isMdOutput = hasExtension(output, 'md')
+    const isHwpOutput = hasExtension(output, 'hwp')
+    const isHwpxOutput = hasExtension(output, 'hwpx')
 
     if (!options.force) {
       try {
@@ -36,27 +40,116 @@ export async function convertCommand(input: string, output: string, options: Con
       }
     }
 
-    const doc = await loadHwp(input)
-    const buffer = await generateHwpx(doc)
+    if (isMdInput && isHwpxOutput) {
+      const md = await readFile(input, 'utf-8')
+      const doc = markdownToHwp(md)
+      const buffer = await generateHwpx(doc)
 
-    await writeFile(output, buffer)
+      await writeFile(output, buffer)
 
-    const paragraphs = doc.sections.reduce((sum, section) => sum + section.paragraphs.length, 0)
-    console.log(
-      formatOutput(
-        {
-          input,
-          output,
-          sections: doc.sections.length,
-          paragraphs,
-          success: true,
-        },
-        options.pretty,
-      ),
-    )
+      const paragraphs = countParagraphs(doc)
+      console.log(
+        formatOutput(
+          {
+            input,
+            output,
+            direction: 'md-to-hwpx',
+            sections: doc.sections.length,
+            paragraphs,
+            success: true,
+          },
+          options.pretty,
+        ),
+      )
+      return
+    }
+
+    if (isMdInput && isHwpOutput) {
+      const md = await readFile(input, 'utf-8')
+      const buffer = await markdownToHwpBinary(md)
+
+      await writeFile(output, buffer)
+
+      console.log(
+        formatOutput(
+          {
+            input,
+            output,
+            direction: 'md-to-hwp',
+            success: true,
+          },
+          options.pretty,
+        ),
+      )
+      return
+    }
+
+    if ((isHwpInput || isHwpxInput) && isMdOutput) {
+      const fmt = await detectFormat(input)
+      const doc = fmt === 'hwp' ? await loadHwp(input) : await loadHwpxDocument(input)
+      const md = hwpToMarkdown(doc)
+
+      await writeFile(output, md, 'utf-8')
+
+      const paragraphs = countParagraphs(doc)
+      console.log(
+        formatOutput(
+          {
+            input,
+            output,
+            direction: 'hwp-to-md',
+            sections: doc.sections.length,
+            paragraphs,
+            success: true,
+          },
+          options.pretty,
+        ),
+      )
+      return
+    }
+
+    if (isHwpInput && isHwpxOutput) {
+      const inputFormat = await detectFormat(input)
+      if (inputFormat !== 'hwp') {
+        throw new Error('Input must be a HWP 5.0 file')
+      }
+
+      const doc = await loadHwp(input)
+      const buffer = await generateHwpx(doc)
+
+      await writeFile(output, buffer)
+
+      const paragraphs = countParagraphs(doc)
+      console.log(
+        formatOutput(
+          {
+            input,
+            output,
+            sections: doc.sections.length,
+            paragraphs,
+            success: true,
+          },
+          options.pretty,
+        ),
+      )
+      return
+    }
+
+    throw new Error(`Unsupported conversion: ${input} -> ${output}`)
   } catch (e) {
     handleError(e)
   }
+}
+
+function countParagraphs(doc: HwpDocument): number {
+  return doc.sections.reduce((sum, section) => sum + section.paragraphs.length, 0)
+}
+
+async function loadHwpxDocument(filePath: string): Promise<HwpDocument> {
+  const archive = await loadHwpx(filePath)
+  const header = parseHeader(await archive.getHeaderXml())
+  const sections = await parseSections(archive)
+  return { format: 'hwpx', sections, header }
 }
 
 export async function generateHwpx(doc: HwpDocument): Promise<Buffer> {

--- a/src/formats/hwpx/section-parser.ts
+++ b/src/formats/hwpx/section-parser.ts
@@ -9,6 +9,7 @@ const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '',
   parseAttributeValue: true,
+  trimValues: false,
   isArray: (name) => ['hp:p', 'hp:run', 'hp:tbl', 'hp:tr', 'hp:tc', 'hp:pic', 'hp:rect'].includes(name),
 })
 
@@ -196,9 +197,13 @@ function extractText(value: unknown): string {
     return value
   }
 
+  if (typeof value === 'number') {
+    return String(value)
+  }
+
   if (value && typeof value === 'object') {
     const text = (value as Record<string, unknown>)['#text']
-    return typeof text === 'string' ? text : ''
+    return typeof text === 'string' ? text : typeof text === 'number' ? String(text) : ''
   }
 
   return ''

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -350,7 +350,7 @@ describe('integration: error cases produce valid JSON', () => {
     restoreOutput()
 
     const output = JSON.parse(errors[0])
-    expect(output.error).toBe('Input must be a HWP 5.0 file')
+    expect(output.error).toContain('Unsupported conversion')
   })
 
   it('text command on HWP 5.0 → succeeds (read supported)', async () => {

--- a/src/markdown/charshape-registry.test.ts
+++ b/src/markdown/charshape-registry.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'bun:test'
+import { CharShapeRegistry } from './charshape-registry'
+
+describe('CharShapeRegistry', () => {
+  it('starts with 1 base shape at index 0 with correct defaults', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    const shapes = registry.getCharShapes()
+
+    expect(shapes).toHaveLength(1)
+    expect(shapes[0]).toEqual({
+      id: 0,
+      fontRef: 1,
+      fontSize: 12,
+      bold: false,
+      italic: false,
+      underline: false,
+      color: '#000000',
+    })
+  })
+
+  it('getRef({}) returns 0 and does not create new shape', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    const ref = registry.getRef({})
+
+    expect(ref).toBe(0)
+    expect(registry.getCharShapes()).toHaveLength(1)
+  })
+
+  it('getRef({ bold: true }) creates shape at index 1 with bold=true', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    const ref = registry.getRef({ bold: true })
+
+    expect(ref).toBe(1)
+    const shapes = registry.getCharShapes()
+    expect(shapes).toHaveLength(2)
+    expect(shapes[1]).toEqual({
+      id: 1,
+      fontRef: 1,
+      fontSize: 12,
+      bold: true,
+      italic: false,
+      underline: false,
+      color: '#000000',
+    })
+  })
+
+  it('getRef({ italic: true }) creates shape at index 2 with italic=true', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    registry.getRef({ bold: true })
+    const ref = registry.getRef({ italic: true })
+
+    expect(ref).toBe(2)
+    const shapes = registry.getCharShapes()
+    expect(shapes).toHaveLength(3)
+    expect(shapes[2]).toEqual({
+      id: 2,
+      fontRef: 1,
+      fontSize: 12,
+      bold: false,
+      italic: true,
+      underline: false,
+      color: '#000000',
+    })
+  })
+
+  it('getRef({ bold: true, italic: true }) creates distinct shape (combo)', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    registry.getRef({ bold: true })
+    registry.getRef({ italic: true })
+    const ref = registry.getRef({ bold: true, italic: true })
+
+    expect(ref).toBe(3)
+    const shapes = registry.getCharShapes()
+    expect(shapes).toHaveLength(4)
+    expect(shapes[3]).toEqual({
+      id: 3,
+      fontRef: 1,
+      fontSize: 12,
+      bold: true,
+      italic: true,
+      underline: false,
+      color: '#000000',
+    })
+  })
+
+  it('calling getRef({ bold: true }) twice returns same index (deduplication)', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    const ref1 = registry.getRef({ bold: true })
+    const ref2 = registry.getRef({ bold: true })
+
+    expect(ref1).toBe(ref2)
+    expect(ref1).toBe(1)
+    expect(registry.getCharShapes()).toHaveLength(2)
+  })
+
+  it('getRef({ bold: true, fontRef: 1 }) creates distinct shape (different fontRef)', () => {
+    const registry = new CharShapeRegistry(0, 12)
+    const ref1 = registry.getRef({ bold: true })
+    const ref2 = registry.getRef({ bold: true, fontRef: 1 })
+
+    expect(ref1).toBe(1)
+    expect(ref2).toBe(2)
+    const shapes = registry.getCharShapes()
+    expect(shapes).toHaveLength(3)
+    expect(shapes[1].fontRef).toBe(0)
+    expect(shapes[2].fontRef).toBe(1)
+  })
+
+  it('getCharShapes() returns array where every shape id equals its array index', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    registry.getRef({ bold: true })
+    registry.getRef({ italic: true })
+    registry.getRef({ bold: true, italic: true })
+
+    const shapes = registry.getCharShapes()
+    shapes.forEach((shape, index) => {
+      expect(shape.id).toBe(index)
+    })
+  })
+
+  it('base fontSize preserved in all created shapes', () => {
+    const registry = new CharShapeRegistry(1, 16)
+    registry.getRef({ bold: true })
+    registry.getRef({ italic: true })
+    registry.getRef({ underline: true })
+
+    const shapes = registry.getCharShapes()
+    shapes.forEach((shape) => {
+      expect(shape.fontSize).toBe(16)
+    })
+  })
+
+  it('getRef({ underline: true }) creates distinct shape from bold/italic', () => {
+    const registry = new CharShapeRegistry(1, 12)
+    const ref1 = registry.getRef({ bold: true })
+    const ref2 = registry.getRef({ italic: true })
+    const ref3 = registry.getRef({ underline: true })
+
+    expect(ref1).toBe(1)
+    expect(ref2).toBe(2)
+    expect(ref3).toBe(3)
+    expect(registry.getCharShapes()).toHaveLength(4)
+  })
+
+  it('uses custom base color when provided', () => {
+    const registry = new CharShapeRegistry(1, 12, '#FF0000')
+    const shapes = registry.getCharShapes()
+
+    expect(shapes[0].color).toBe('#FF0000')
+  })
+
+  it('preserves base color in all created shapes', () => {
+    const registry = new CharShapeRegistry(1, 12, '#00FF00')
+    registry.getRef({ bold: true })
+    registry.getRef({ italic: true })
+
+    const shapes = registry.getCharShapes()
+    shapes.forEach((shape) => {
+      expect(shape.color).toBe('#00FF00')
+    })
+  })
+})

--- a/src/markdown/charshape-registry.ts
+++ b/src/markdown/charshape-registry.ts
@@ -1,0 +1,68 @@
+import type { CharShape } from '@/types'
+
+type CharShapeOptions = {
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  fontRef?: number
+}
+
+export class CharShapeRegistry {
+  private shapes: CharShape[] = []
+  private keyMap: Map<string, number> = new Map()
+  private baseFontRef: number
+  private baseFontSize: number
+  private baseColor: string
+
+  constructor(baseFontRef: number, baseFontSize: number, baseColor: string = '#000000') {
+    this.baseFontRef = baseFontRef
+    this.baseFontSize = baseFontSize
+    this.baseColor = baseColor
+
+    const baseShape: CharShape = {
+      id: 0,
+      fontRef: baseFontRef,
+      fontSize: baseFontSize,
+      bold: false,
+      italic: false,
+      underline: false,
+      color: baseColor,
+    }
+
+    this.shapes.push(baseShape)
+    this.keyMap.set(`${baseFontRef}:false:false:false`, 0)
+  }
+
+  getRef(options: CharShapeOptions = {}): number {
+    const fontRef = options.fontRef ?? this.baseFontRef
+    const bold = options.bold ?? false
+    const italic = options.italic ?? false
+    const underline = options.underline ?? false
+
+    const key = `${fontRef}:${bold}:${italic}:${underline}`
+
+    if (this.keyMap.has(key)) {
+      return this.keyMap.get(key)!
+    }
+
+    const newShape: CharShape = {
+      id: this.shapes.length,
+      fontRef,
+      fontSize: this.baseFontSize,
+      bold,
+      italic,
+      underline,
+      color: this.baseColor,
+    }
+
+    const index = this.shapes.length
+    this.shapes.push(newShape)
+    this.keyMap.set(key, index)
+
+    return index
+  }
+
+  getCharShapes(): CharShape[] {
+    return this.shapes
+  }
+}

--- a/src/markdown/heading-styles.test.ts
+++ b/src/markdown/heading-styles.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'bun:test'
+import type { Paragraph, ParaShape, Style } from '@/types'
+import {
+  headingStyleName,
+  getHeadingLevel,
+  createHeadingInfrastructure,
+} from './heading-styles'
+
+describe('headingStyleName', () => {
+  it('maps level 1 to "개요 1"', () => {
+    expect(headingStyleName(1)).toBe('개요 1')
+  })
+
+  it('maps level 6 to "개요 6"', () => {
+    expect(headingStyleName(6)).toBe('개요 6')
+  })
+
+  it('caps level 7 to "개요 7"', () => {
+    expect(headingStyleName(7)).toBe('개요 7')
+  })
+
+  it('caps level 10 to "개요 7"', () => {
+    expect(headingStyleName(10)).toBe('개요 7')
+  })
+
+  it('treats level 0 as level 1', () => {
+    expect(headingStyleName(0)).toBe('개요 1')
+  })
+
+  it('treats negative level as level 1', () => {
+    expect(headingStyleName(-5)).toBe('개요 1')
+  })
+})
+
+describe('getHeadingLevel', () => {
+  it('detects heading from style name "개요 3"', () => {
+    const paragraph: Paragraph = {
+      ref: 's0.p0',
+      runs: [],
+      paraShapeRef: 1,
+      styleRef: 10,
+    }
+    const styles: Style[] = [
+      {
+        id: 10,
+        name: '개요 3',
+        charShapeRef: 1,
+        paraShapeRef: 1,
+        type: 'PARA',
+      },
+    ]
+    const paraShapes: ParaShape[] = []
+
+    expect(getHeadingLevel(paragraph, styles, paraShapes)).toBe(3)
+  })
+
+  it('detects heading from English "Heading 2"', () => {
+    const paragraph: Paragraph = {
+      ref: 's0.p0',
+      runs: [],
+      paraShapeRef: 1,
+      styleRef: 10,
+    }
+    const styles: Style[] = [
+      {
+        id: 10,
+        name: 'Heading 2',
+        charShapeRef: 1,
+        paraShapeRef: 1,
+        type: 'PARA',
+      },
+    ]
+    const paraShapes: ParaShape[] = []
+
+    expect(getHeadingLevel(paragraph, styles, paraShapes)).toBe(2)
+  })
+
+  it('detects heading from English "Outline 1"', () => {
+    const paragraph: Paragraph = {
+      ref: 's0.p0',
+      runs: [],
+      paraShapeRef: 1,
+      styleRef: 10,
+    }
+    const styles: Style[] = [
+      {
+        id: 10,
+        name: 'Outline 1',
+        charShapeRef: 1,
+        paraShapeRef: 1,
+        type: 'PARA',
+      },
+    ]
+    const paraShapes: ParaShape[] = []
+
+    expect(getHeadingLevel(paragraph, styles, paraShapes)).toBe(1)
+  })
+
+  it('detects from paraShape.headingLevel when style name does not match', () => {
+    const paragraph: Paragraph = {
+      ref: 's0.p0',
+      runs: [],
+      paraShapeRef: 5,
+      styleRef: 10,
+    }
+    const styles: Style[] = [
+      {
+        id: 10,
+        name: 'Normal',
+        charShapeRef: 1,
+        paraShapeRef: 5,
+        type: 'PARA',
+      },
+    ]
+    const paraShapes: ParaShape[] = [
+      {
+        id: 5,
+        align: 'left',
+        headingLevel: 4,
+      },
+    ]
+
+    expect(getHeadingLevel(paragraph, styles, paraShapes)).toBe(4)
+  })
+
+  it('returns null for body paragraph', () => {
+    const paragraph: Paragraph = {
+      ref: 's0.p0',
+      runs: [],
+      paraShapeRef: 1,
+      styleRef: 10,
+    }
+    const styles: Style[] = [
+      {
+        id: 10,
+        name: 'Normal',
+        charShapeRef: 1,
+        paraShapeRef: 1,
+        type: 'PARA',
+      },
+    ]
+    const paraShapes: ParaShape[] = [
+      {
+        id: 1,
+        align: 'left',
+      },
+    ]
+
+    expect(getHeadingLevel(paragraph, styles, paraShapes)).toBeNull()
+  })
+
+  it('prioritizes style name over paraShape.headingLevel', () => {
+    const paragraph: Paragraph = {
+      ref: 's0.p0',
+      runs: [],
+      paraShapeRef: 5,
+      styleRef: 10,
+    }
+    const styles: Style[] = [
+      {
+        id: 10,
+        name: '개요 2',
+        charShapeRef: 1,
+        paraShapeRef: 5,
+        type: 'PARA',
+      },
+    ]
+    const paraShapes: ParaShape[] = [
+      {
+        id: 5,
+        align: 'left',
+        headingLevel: 4,
+      },
+    ]
+
+    expect(getHeadingLevel(paragraph, styles, paraShapes)).toBe(2)
+  })
+})
+
+describe('createHeadingInfrastructure', () => {
+  it('creates exactly 6 paraShapes and 6 styles', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    expect(result.paraShapes).toHaveLength(6)
+    expect(result.styles).toHaveLength(6)
+  })
+
+  it('creates sequential IDs from base+1', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    expect(result.paraShapes[0].id).toBe(201)
+    expect(result.paraShapes[1].id).toBe(202)
+    expect(result.paraShapes[5].id).toBe(206)
+
+    expect(result.styles[0].id).toBe(301)
+    expect(result.styles[1].id).toBe(302)
+    expect(result.styles[5].id).toBe(306)
+  })
+
+  it('creates style names "개요 1" through "개요 6"', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    expect(result.styles[0].name).toBe('개요 1')
+    expect(result.styles[1].name).toBe('개요 2')
+    expect(result.styles[5].name).toBe('개요 6')
+  })
+
+  it('sets paraShape.headingLevel to 1-6 respectively', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    expect(result.paraShapes[0].headingLevel).toBe(1)
+    expect(result.paraShapes[1].headingLevel).toBe(2)
+    expect(result.paraShapes[5].headingLevel).toBe(6)
+  })
+
+  it('sets all paraShapes to align left', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    result.paraShapes.forEach((ps) => {
+      expect(ps.align).toBe('left')
+    })
+  })
+
+  it('sets style.type to PARA', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    result.styles.forEach((s) => {
+      expect(s.type).toBe('PARA')
+    })
+  })
+
+  it('sets all styles charShapeRef to baseCharShapeRef', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    result.styles.forEach((s) => {
+      expect(s.charShapeRef).toBe(100)
+    })
+  })
+
+  it('each style paraShapeRef points to corresponding paraShape', () => {
+    const result = createHeadingInfrastructure(100, 200, 300)
+
+    for (let i = 0; i < 6; i++) {
+      expect(result.styles[i].paraShapeRef).toBe(result.paraShapes[i].id)
+    }
+  })
+})

--- a/src/markdown/heading-styles.ts
+++ b/src/markdown/heading-styles.ts
@@ -1,0 +1,83 @@
+import type { Paragraph, ParaShape, Style } from '@/types'
+
+const HEADING_REGEX = /^(?:개요|Outline|Heading)\s+(\d+)$/i
+
+export function headingStyleName(level: number): string {
+  const normalizedLevel = Math.max(1, Math.min(level, 7))
+  return `개요 ${normalizedLevel}`
+}
+
+export function getHeadingLevel(
+  paragraph: Paragraph,
+  styles: Style[],
+  paraShapes: ParaShape[]
+): number | null {
+  const headingLevelFromStyleName = extractHeadingLevelFromStyle(
+    paragraph.styleRef,
+    styles
+  )
+  if (headingLevelFromStyleName !== null) {
+    return headingLevelFromStyleName
+  }
+
+  return extractHeadingLevelFromParaShape(paragraph.paraShapeRef, paraShapes)
+}
+
+function extractHeadingLevelFromStyle(
+  styleRef: number,
+  styles: Style[]
+): number | null {
+  const style = styles.find((s) => s.id === styleRef)
+  if (!style) {
+    return null
+  }
+
+  const match = style.name.match(HEADING_REGEX)
+  if (!match) {
+    return null
+  }
+
+  return parseInt(match[1], 10)
+}
+
+function extractHeadingLevelFromParaShape(
+  paraShapeRef: number,
+  paraShapes: ParaShape[]
+): number | null {
+  const paraShape = paraShapes.find((ps) => ps.id === paraShapeRef)
+  if (!paraShape || paraShape.headingLevel === undefined) {
+    return null
+  }
+
+  return paraShape.headingLevel
+}
+
+export function createHeadingInfrastructure(
+  baseCharShapeRef: number,
+  baseParaShapeId: number,
+  baseStyleId: number
+): { paraShapes: ParaShape[]; styles: Style[] } {
+  const paraShapes: ParaShape[] = []
+  const styles: Style[] = []
+
+  for (let i = 1; i <= 6; i++) {
+    const paraShapeId = baseParaShapeId + i
+    const styleId = baseStyleId + i
+
+    paraShapes.push({
+      id: paraShapeId,
+      align: 'left',
+      headingLevel: i,
+    })
+
+    styles.push({
+      id: styleId,
+      name: `개요 ${i}`,
+      charShapeRef: baseCharShapeRef,
+      paraShapeRef: paraShapeId,
+      type: 'PARA',
+    })
+  }
+
+  return { paraShapes, styles }
+}

--- a/src/markdown/image-handler.test.ts
+++ b/src/markdown/image-handler.test.ts
@@ -1,0 +1,289 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import JSZip from 'jszip'
+import type { Image } from '@/types'
+import { embedImage, extractImages, resolveImagePaths } from './image-handler'
+
+const PNG_BYTES = Buffer.from([
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a,
+])
+
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0])
+
+let testDir = ''
+
+beforeAll(async () => {
+  testDir = join(tmpdir(), `image-handler-${Date.now()}`)
+  await mkdir(testDir, { recursive: true })
+})
+
+afterAll(async () => {
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+  }
+})
+
+describe('resolveImagePaths', () => {
+  it('resolves relative path correctly against baseDir', async () => {
+    const baseDir = join(testDir, 'resolve-relative')
+    const imagePath = join(baseDir, 'assets', 'photo.png')
+    await mkdir(join(baseDir, 'assets'), { recursive: true })
+    await writeFile(imagePath, PNG_BYTES)
+
+    const [result] = resolveImagePaths(
+      [{ url: 'assets/photo.png', alt: 'photo' }],
+      baseDir,
+    )
+
+    expect(result).toEqual({
+      url: 'assets/photo.png',
+      alt: 'photo',
+      resolvedPath: imagePath,
+    })
+  })
+
+  it('returns absolute path as-is when file exists', async () => {
+    const imagePath = join(testDir, 'absolute.png')
+    await writeFile(imagePath, PNG_BYTES)
+
+    const [result] = resolveImagePaths([{ url: imagePath, alt: 'abs' }], testDir)
+
+    expect(result).toEqual({
+      url: imagePath,
+      alt: 'abs',
+      resolvedPath: imagePath,
+    })
+  })
+
+  it('returns warning for remote URLs', () => {
+    const [result] = resolveImagePaths(
+      [{ url: 'https://example.com/image.png', alt: 'remote' }],
+      testDir,
+    )
+
+    expect(result.resolvedPath).toBeNull()
+    expect(result.warning).toContain('Remote')
+  })
+
+  it('returns warning for missing local files', () => {
+    const missingPath = join(testDir, 'missing.png')
+    const [result] = resolveImagePaths([{ url: 'missing.png', alt: 'missing' }], testDir)
+
+    expect(result.resolvedPath).toBeNull()
+    expect(result.warning).toBeDefined()
+    expect(result.warning).toContain(missingPath)
+  })
+
+  it('resolves multiple images in one call', async () => {
+    const baseDir = join(testDir, 'resolve-multiple')
+    const relativePath = join(baseDir, 'relative.png')
+    const absolutePath = join(testDir, 'absolute-multiple.png')
+    await mkdir(baseDir, { recursive: true })
+    await writeFile(relativePath, PNG_BYTES)
+    await writeFile(absolutePath, PNG_BYTES)
+
+    const results = resolveImagePaths(
+      [
+        { url: 'relative.png', alt: 'relative' },
+        { url: absolutePath, alt: 'absolute' },
+      ],
+      baseDir,
+    )
+
+    expect(results).toEqual([
+      { url: 'relative.png', alt: 'relative', resolvedPath: relativePath },
+      { url: absolutePath, alt: 'absolute', resolvedPath: absolutePath },
+    ])
+  })
+})
+
+describe('embedImage', () => {
+  it('embeds PNG file into ZIP at BinData/image0.png', async () => {
+    const imagePath = join(testDir, 'embed-0.png')
+    await writeFile(imagePath, PNG_BYTES)
+    const zip = new JSZip()
+
+    await embedImage(zip, imagePath, 0)
+
+    expect(zip.file('BinData/image0.png')).not.toBeNull()
+  })
+
+  it('returns Image with ref s0.img0 and format png', async () => {
+    const imagePath = join(testDir, 'embed-meta.png')
+    await writeFile(imagePath, PNG_BYTES)
+    const zip = new JSZip()
+
+    const result = await embedImage(zip, imagePath, 0)
+
+    expect(result).toEqual({
+      ref: 's0.img0',
+      binDataPath: 'BinData/image0.png',
+      width: 0,
+      height: 0,
+      format: 'png',
+    })
+  })
+
+  it('uses index 1 for BinData/image1.png and s0.img1', async () => {
+    const imagePath = join(testDir, 'embed-1.png')
+    await writeFile(imagePath, PNG_BYTES)
+    const zip = new JSZip()
+
+    const result = await embedImage(zip, imagePath, 1)
+
+    expect(zip.file('BinData/image1.png')).not.toBeNull()
+    expect(result.ref).toBe('s0.img1')
+    expect(result.binDataPath).toBe('BinData/image1.png')
+  })
+
+  it('normalizes .jpeg extension to jpg format', async () => {
+    const imagePath = join(testDir, 'embed-jpeg.jpeg')
+    await writeFile(imagePath, JPEG_BYTES)
+    const zip = new JSZip()
+
+    const result = await embedImage(zip, imagePath, 2)
+
+    expect(result.format).toBe('jpg')
+    expect(result.binDataPath).toBe('BinData/image2.jpg')
+    expect(zip.file('BinData/image2.jpg')).not.toBeNull()
+  })
+
+  it('adds actual file bytes to the zip entry', async () => {
+    const imagePath = join(testDir, 'embed-bytes.png')
+    await writeFile(imagePath, PNG_BYTES)
+    const zip = new JSZip()
+
+    await embedImage(zip, imagePath, 0)
+
+    const file = zip.file('BinData/image0.png')
+    expect(file).not.toBeNull()
+    const extracted = await file!.async('nodebuffer')
+    expect(extracted).toEqual(PNG_BYTES)
+  })
+})
+
+describe('extractImages', () => {
+  it('extracts image from ZIP to outputDir and returns path map', async () => {
+    const hwpxPath = join(testDir, 'single.hwpx')
+    const outputDir = join(testDir, 'extract-single')
+    const zip = new JSZip()
+    zip.file('BinData/image0.png', PNG_BYTES)
+    await writeFile(hwpxPath, await zip.generateAsync({ type: 'nodebuffer' }))
+
+    const images: Image[] = [
+      {
+        ref: 's0.img0',
+        binDataPath: 'BinData/image0.png',
+        width: 0,
+        height: 0,
+        format: 'png',
+      },
+    ]
+
+    const result = await extractImages(hwpxPath, images, outputDir)
+    const extractedPath = join(outputDir, 'image0.png')
+
+    expect(existsSync(extractedPath)).toBe(true)
+    expect(result.get('BinData/image0.png')).toBe('image0.png')
+  })
+
+  it('warns and skips missing BinData entries', async () => {
+    const hwpxPath = join(testDir, 'missing-entry.hwpx')
+    const outputDir = join(testDir, 'extract-missing')
+    const zip = new JSZip()
+    await writeFile(hwpxPath, await zip.generateAsync({ type: 'nodebuffer' }))
+
+    const images: Image[] = [
+      {
+        ref: 's0.img0',
+        binDataPath: 'BinData/image0.png',
+        width: 0,
+        height: 0,
+        format: 'png',
+      },
+    ]
+
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(' '))
+    }
+
+    try {
+      const result = await extractImages(hwpxPath, images, outputDir)
+
+      expect(result.size).toBe(0)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]).toContain('BinData/image0.png')
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+
+  it('creates outputDir if it does not exist', async () => {
+    const hwpxPath = join(testDir, 'create-dir.hwpx')
+    const outputDir = join(testDir, 'nested', 'images')
+    const zip = new JSZip()
+    zip.file('BinData/image0.png', PNG_BYTES)
+    await writeFile(hwpxPath, await zip.generateAsync({ type: 'nodebuffer' }))
+
+    const images: Image[] = [
+      {
+        ref: 's0.img0',
+        binDataPath: 'BinData/image0.png',
+        width: 0,
+        height: 0,
+        format: 'png',
+      },
+    ]
+
+    await extractImages(hwpxPath, images, outputDir)
+
+    expect(existsSync(outputDir)).toBe(true)
+    expect(existsSync(join(outputDir, 'image0.png'))).toBe(true)
+  })
+
+  it('extracts multiple images and returns all map entries', async () => {
+    const hwpxPath = join(testDir, 'multiple.hwpx')
+    const outputDir = join(testDir, 'extract-multiple')
+    const zip = new JSZip()
+    zip.file('BinData/image0.png', PNG_BYTES)
+    zip.file('BinData/image1.jpg', JPEG_BYTES)
+    await writeFile(hwpxPath, await zip.generateAsync({ type: 'nodebuffer' }))
+
+    const images: Image[] = [
+      {
+        ref: 's0.img0',
+        binDataPath: 'BinData/image0.png',
+        width: 0,
+        height: 0,
+        format: 'png',
+      },
+      {
+        ref: 's0.img1',
+        binDataPath: 'BinData/image1.jpg',
+        width: 0,
+        height: 0,
+        format: 'jpg',
+      },
+    ]
+
+    const result = await extractImages(hwpxPath, images, outputDir)
+
+    expect(existsSync(join(outputDir, 'image0.png'))).toBe(true)
+    expect(existsSync(join(outputDir, 'image1.jpg'))).toBe(true)
+    expect(result.size).toBe(2)
+    expect(result.get('BinData/image0.png')).toBe('image0.png')
+    expect(result.get('BinData/image1.jpg')).toBe('image1.jpg')
+  })
+})

--- a/src/markdown/image-handler.ts
+++ b/src/markdown/image-handler.ts
@@ -1,0 +1,108 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, extname, isAbsolute, join, resolve } from 'node:path'
+import JSZip from 'jszip'
+import type { Image } from '@/types'
+
+export async function extractImages(
+  inputPath: string,
+  images: Image[],
+  outputDir: string,
+): Promise<Map<string, string>> {
+  const data = await readFile(inputPath)
+  const zip = await JSZip.loadAsync(data)
+  const extractedPaths = new Map<string, string>()
+
+  await mkdir(outputDir, { recursive: true })
+
+  for (const image of images) {
+    const file = zip.file(image.binDataPath)
+
+    if (!file) {
+      console.warn(`Image not found in archive: ${image.binDataPath}`)
+      continue
+    }
+
+    const filename = basename(image.binDataPath)
+    const outputPath = join(outputDir, filename)
+    const bytes = await file.async('nodebuffer')
+
+    await writeFile(outputPath, bytes)
+    extractedPaths.set(image.binDataPath, filename)
+  }
+
+  return extractedPaths
+}
+
+export function resolveImagePaths(
+  mdImages: Array<{ url: string; alt: string }>,
+  baseDir: string,
+): Array<{
+  url: string
+  alt: string
+  resolvedPath: string | null
+  warning?: string
+}> {
+  return mdImages.map((image) => {
+    if (image.url.startsWith('http://') || image.url.startsWith('https://')) {
+      return {
+        ...image,
+        resolvedPath: null,
+        warning: 'Remote URLs not supported',
+      }
+    }
+
+    const resolvedPath = isAbsolute(image.url)
+      ? image.url
+      : resolve(baseDir, image.url)
+
+    if (!existsSync(resolvedPath)) {
+      return {
+        ...image,
+        resolvedPath: null,
+        warning: `File not found: ${resolvedPath}`,
+      }
+    }
+
+    return {
+      ...image,
+      resolvedPath,
+    }
+  })
+}
+
+export async function embedImage(
+  zip: JSZip,
+  localPath: string,
+  index: number,
+): Promise<Image> {
+  const bytes = await readFile(localPath)
+  const format = normalizeImageFormat(extname(localPath))
+  const binDataPath = `BinData/image${index}.${format}`
+
+  zip.file(binDataPath, bytes)
+
+  return {
+    ref: `s0.img${index}`,
+    binDataPath,
+    width: 0,
+    height: 0,
+    format,
+  }
+}
+
+function normalizeImageFormat(extension: string): string {
+  switch (extension.toLowerCase()) {
+    case '.jpeg':
+    case '.jpg':
+      return 'jpg'
+    case '.png':
+      return 'png'
+    case '.gif':
+      return 'gif'
+    case '.bmp':
+      return 'bmp'
+    default:
+      throw new Error(`Unsupported image format: ${extension}`)
+  }
+}

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -1,0 +1,2 @@
+// Markdown ↔ HWP(X) conversion — barrel file
+// Exports will be added as modules are implemented

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -1,6 +1,6 @@
 export { CharShapeRegistry } from './charshape-registry'
 export { createHeadingInfrastructure, getHeadingLevel } from './heading-styles'
 export { embedImage, extractImages, resolveImagePaths } from './image-handler'
-export { markdownToHwpBinary } from './to-hwp-binary'
+export { markdownToHwpBinary, type MarkdownToHwpBinaryResult } from './to-hwp-binary'
 export { markdownToHwp } from './to-hwp'
 export { hwpToMarkdown } from './to-markdown'

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -1,2 +1,6 @@
-// Markdown ↔ HWP(X) conversion — barrel file
-// Exports will be added as modules are implemented
+export { CharShapeRegistry } from './charshape-registry'
+export { createHeadingInfrastructure, getHeadingLevel } from './heading-styles'
+export { embedImage, extractImages, resolveImagePaths } from './image-handler'
+export { markdownToHwpBinary } from './to-hwp-binary'
+export { markdownToHwp } from './to-hwp'
+export { hwpToMarkdown } from './to-markdown'

--- a/src/markdown/to-hwp-binary.test.ts
+++ b/src/markdown/to-hwp-binary.test.ts
@@ -72,6 +72,35 @@ describe('markdownToHwpBinary', () => {
     expect(doc.sections[0].tables).toHaveLength(1)
   })
 
+  it('converts mixed-format paragraph to valid HWP without throwing', async () => {
+    const buffer = await markdownToHwpBinary('Hello **bold** and *italic* text')
+    const path = await writeTempHwp(buffer)
+    const doc = await loadHwp(path)
+    const text = doc.sections[0].paragraphs
+      .map((paragraph) => paragraph.runs.map((run) => run.text).join(''))
+      .filter((paragraphText) => paragraphText.length > 0)
+      .join(' ')
+
+    expect(text).toContain('Hello bold and italic text')
+  })
+
+  it('applies uniform bold formatting to all-bold paragraph', async () => {
+    const buffer = await markdownToHwpBinary('**entire paragraph bold**')
+    const path = await writeTempHwp(buffer)
+    const doc = await loadHwp(path)
+    const para = doc.sections[0].paragraphs.find(
+      (paragraph) => paragraph.runs.map((run) => run.text).join('').length > 0,
+    )
+
+    expect(para).toBeDefined()
+    if (!para) {
+      throw new Error('Expected non-empty paragraph')
+    }
+
+    const charShape = doc.header.charShapes[para.runs[0].charShapeRef]
+    expect(charShape.bold).toBe(true)
+  })
+
   it('skips images and still returns valid HWP buffer', async () => {
     const warnings: string[] = []
     const originalWarn = console.warn

--- a/src/markdown/to-hwp-binary.test.ts
+++ b/src/markdown/to-hwp-binary.test.ts
@@ -27,19 +27,19 @@ async function writeTempHwp(buffer: Buffer): Promise<string> {
 
 describe('markdownToHwpBinary', () => {
   it('returns Buffer', async () => {
-    const buffer = await markdownToHwpBinary('Hello')
+    const { buffer } = await markdownToHwpBinary('Hello')
 
     expect(Buffer.isBuffer(buffer)).toBe(true)
   })
 
   it('returns HWP CFB magic bytes', async () => {
-    const buffer = await markdownToHwpBinary('Hello')
+    const { buffer } = await markdownToHwpBinary('Hello')
 
     expect([...buffer.subarray(0, 4)]).toEqual([0xd0, 0xcf, 0x11, 0xe0])
   })
 
   it('keeps plain text paragraph content', async () => {
-    const buffer = await markdownToHwpBinary('Hello\n\nWorld')
+    const { buffer } = await markdownToHwpBinary('Hello\n\nWorld')
     const path = await writeTempHwp(buffer)
     const doc = await loadHwp(path)
     const texts = doc.sections[0].paragraphs
@@ -50,7 +50,7 @@ describe('markdownToHwpBinary', () => {
   })
 
   it('preserves heading level on heading paragraph', async () => {
-    const buffer = await markdownToHwpBinary('# Title\n\nBody')
+    const { buffer } = await markdownToHwpBinary('# Title\n\nBody')
     const path = await writeTempHwp(buffer)
     const doc = await loadHwp(path)
     const headingPara = doc.sections[0].paragraphs.find(
@@ -65,7 +65,7 @@ describe('markdownToHwpBinary', () => {
   })
 
   it('converts markdown table into HWP table', async () => {
-    const buffer = await markdownToHwpBinary('| A | B |\n|---|---|\n| 1 | 2 |')
+    const { buffer } = await markdownToHwpBinary('| A | B |\n|---|---|\n| 1 | 2 |')
     const path = await writeTempHwp(buffer)
     const doc = await loadHwp(path)
 
@@ -73,7 +73,7 @@ describe('markdownToHwpBinary', () => {
   })
 
   it('converts mixed-format paragraph to valid HWP without throwing', async () => {
-    const buffer = await markdownToHwpBinary('Hello **bold** and *italic* text')
+    const { buffer } = await markdownToHwpBinary('Hello **bold** and *italic* text')
     const path = await writeTempHwp(buffer)
     const doc = await loadHwp(path)
     const text = doc.sections[0].paragraphs
@@ -85,7 +85,7 @@ describe('markdownToHwpBinary', () => {
   })
 
   it('applies uniform bold formatting to all-bold paragraph', async () => {
-    const buffer = await markdownToHwpBinary('**entire paragraph bold**')
+    const { buffer } = await markdownToHwpBinary('**entire paragraph bold**')
     const path = await writeTempHwp(buffer)
     const doc = await loadHwp(path)
     const para = doc.sections[0].paragraphs.find(
@@ -109,7 +109,7 @@ describe('markdownToHwpBinary', () => {
     }
 
     try {
-      const buffer = await markdownToHwpBinary('![alt](./img.png)')
+      const { buffer } = await markdownToHwpBinary('![alt](./img.png)')
       const path = await writeTempHwp(buffer)
       const doc = await loadHwp(path)
 
@@ -122,7 +122,7 @@ describe('markdownToHwpBinary', () => {
   })
 
   it('flattens multi-section markdown into single HWP section', async () => {
-    const buffer = await markdownToHwpBinary('Section 1\n\n---\n\nSection 2')
+    const { buffer } = await markdownToHwpBinary('Section 1\n\n---\n\nSection 2')
     const path = await writeTempHwp(buffer)
     const doc = await loadHwp(path)
     const texts = doc.sections[0].paragraphs.map((paragraph) => paragraph.runs.map((run) => run.text).join(''))

--- a/src/markdown/to-hwp-binary.test.ts
+++ b/src/markdown/to-hwp-binary.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { unlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { loadHwp } from '@/formats/hwp/reader'
+
+import { markdownToHwpBinary } from './to-hwp-binary'
+
+const tempFiles = new Set<string>()
+
+afterEach(async () => {
+  await Promise.all(
+    [...tempFiles].map(async (filePath) => {
+      tempFiles.delete(filePath)
+      await unlink(filePath).catch(() => {})
+    }),
+  )
+})
+
+async function writeTempHwp(buffer: Buffer): Promise<string> {
+  const path = join(tmpdir(), `markdown-to-hwp-binary-test-${Date.now()}-${Math.random().toString(16).slice(2)}.hwp`)
+  tempFiles.add(path)
+  await writeFile(path, buffer)
+  return path
+}
+
+describe('markdownToHwpBinary', () => {
+  it('returns Buffer', async () => {
+    const buffer = await markdownToHwpBinary('Hello')
+
+    expect(Buffer.isBuffer(buffer)).toBe(true)
+  })
+
+  it('returns HWP CFB magic bytes', async () => {
+    const buffer = await markdownToHwpBinary('Hello')
+
+    expect([...buffer.subarray(0, 4)]).toEqual([0xd0, 0xcf, 0x11, 0xe0])
+  })
+
+  it('keeps plain text paragraph content', async () => {
+    const buffer = await markdownToHwpBinary('Hello\n\nWorld')
+    const path = await writeTempHwp(buffer)
+    const doc = await loadHwp(path)
+    const texts = doc.sections[0].paragraphs
+      .map((paragraph) => paragraph.runs.map((run) => run.text).join(''))
+      .filter((text) => text.length > 0)
+
+    expect(texts).toEqual(['Hello', 'World'])
+  })
+
+  it('preserves heading level on heading paragraph', async () => {
+    const buffer = await markdownToHwpBinary('# Title\n\nBody')
+    const path = await writeTempHwp(buffer)
+    const doc = await loadHwp(path)
+    const headingPara = doc.sections[0].paragraphs.find(
+      (paragraph) => paragraph.runs.map((run) => run.text).join('').length > 0,
+    )
+
+    expect(headingPara).toBeDefined()
+
+    const paraShape = doc.header.paraShapes[headingPara.paraShapeRef]
+
+    expect(paraShape.headingLevel).toBeGreaterThan(0)
+  })
+
+  it('converts markdown table into HWP table', async () => {
+    const buffer = await markdownToHwpBinary('| A | B |\n|---|---|\n| 1 | 2 |')
+    const path = await writeTempHwp(buffer)
+    const doc = await loadHwp(path)
+
+    expect(doc.sections[0].tables).toHaveLength(1)
+  })
+
+  it('skips images and still returns valid HWP buffer', async () => {
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(' '))
+    }
+
+    try {
+      const buffer = await markdownToHwpBinary('![alt](./img.png)')
+      const path = await writeTempHwp(buffer)
+      const doc = await loadHwp(path)
+
+      expect(Buffer.isBuffer(buffer)).toBe(true)
+      expect(doc.format).toBe('hwp')
+      expect(warnings.some((warning) => warning.includes('images are not supported in HWP binary output'))).toBe(true)
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+
+  it('flattens multi-section markdown into single HWP section', async () => {
+    const buffer = await markdownToHwpBinary('Section 1\n\n---\n\nSection 2')
+    const path = await writeTempHwp(buffer)
+    const doc = await loadHwp(path)
+    const texts = doc.sections[0].paragraphs.map((paragraph) => paragraph.runs.map((run) => run.text).join(''))
+
+    expect(doc.sections).toHaveLength(1)
+    expect(texts).toContain('Section 1')
+    expect(texts).toContain('Section 2')
+  })
+})

--- a/src/markdown/to-hwp-binary.ts
+++ b/src/markdown/to-hwp-binary.ts
@@ -1,3 +1,126 @@
-export async function markdownToHwpBinary(_md: string): Promise<Buffer> {
-  throw new Error('MD→HWP binary conversion not yet implemented')
+import { readFile, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createHwp } from '@/formats/hwp/creator'
+import { editHwp } from '@/formats/hwp/writer'
+import { markdownToHwp } from '@/markdown/to-hwp'
+import type { EditOperation } from '@/shared/edit-types'
+import type { HwpDocument, Paragraph, Table } from '@/types'
+
+type FlattenedItem =
+  | { type: 'paragraph'; paragraph: Paragraph }
+  | { type: 'table'; table: Table }
+  | { type: 'sectionSeparator' }
+
+export async function markdownToHwpBinary(md: string): Promise<Buffer> {
+  const doc = markdownToHwp(md)
+
+  if (doc.sections.some((section) => section.images.length > 0)) {
+    console.warn('Warning: images are not supported in HWP binary output and will be skipped')
+  }
+
+  const flattenedItems = flattenSections(doc)
+  const structureOps: EditOperation[] = []
+  const formatOps: EditOperation[] = []
+  const paragraphTargets: Array<{ paragraph: Paragraph; paragraphIndex: number }> = []
+
+  let paragraphIndex = 0
+  for (const item of flattenedItems) {
+    if (item.type === 'paragraph') {
+      const headingLevel = doc.header.paraShapes[item.paragraph.paraShapeRef]?.headingLevel
+      const heading = headingLevel && headingLevel > 0 ? headingLevel : undefined
+      const text = item.paragraph.runs.map((run) => run.text).join('')
+
+      structureOps.push({
+        type: 'addParagraph',
+        ref: 's0',
+        text,
+        position: 'end',
+        heading,
+      })
+      paragraphTargets.push({ paragraph: item.paragraph, paragraphIndex })
+      paragraphIndex += 1
+      continue
+    }
+
+    if (item.type === 'table') {
+      const rowCount = item.table.rows.length
+      const colCount = item.table.rows[0]?.cells.length ?? 0
+      const data = item.table.rows.map((row) =>
+        row.cells.map((cell) => cell.paragraphs[0]?.runs.map((run) => run.text).join('') ?? ''),
+      )
+
+      structureOps.push({
+        type: 'addTable',
+        ref: 's0',
+        rows: rowCount,
+        cols: colCount,
+        data,
+        position: 'end',
+      })
+      continue
+    }
+
+    structureOps.push({
+      type: 'addParagraph',
+      ref: 's0',
+      text: '',
+      position: 'end',
+    })
+    paragraphIndex += 1
+  }
+
+  for (const target of paragraphTargets) {
+    let charOffset = 0
+    for (const run of target.paragraph.runs) {
+      const charShape = doc.header.charShapes[run.charShapeRef]
+      const bold = charShape?.bold === true ? true : undefined
+      const italic = charShape?.italic === true ? true : undefined
+
+      if (run.text.length > 0 && (bold || italic)) {
+        formatOps.push({
+          type: 'setFormat',
+          ref: `s0.p${target.paragraphIndex}`,
+          format: {
+            bold,
+            italic,
+          },
+          start: charOffset,
+          end: charOffset + run.text.length,
+        })
+      }
+
+      charOffset += run.text.length
+    }
+  }
+
+  const tempPath = join(
+    tmpdir(),
+    `hwpilot-markdown-${Date.now()}-${Math.random().toString(16).slice(2)}.hwp`,
+  )
+
+  try {
+    const base = await createHwp({ font: '맑은 고딕', fontSize: 10 })
+    await writeFile(tempPath, base)
+    await editHwp(tempPath, [...structureOps, ...formatOps])
+    return await readFile(tempPath)
+  } finally {
+    await unlink(tempPath).catch(() => {})
+  }
+}
+
+function flattenSections(doc: HwpDocument): FlattenedItem[] {
+  const items: FlattenedItem[] = []
+
+  doc.sections.forEach((section, index) => {
+    items.push(...section.paragraphs.map((paragraph) => ({ type: 'paragraph', paragraph }) as const))
+    items.push(...section.tables.map((table) => ({ type: 'table', table }) as const))
+
+    if (index < doc.sections.length - 1) {
+      items.push({ type: 'sectionSeparator' })
+    }
+  })
+
+  return items
 }

--- a/src/markdown/to-hwp-binary.ts
+++ b/src/markdown/to-hwp-binary.ts
@@ -81,7 +81,7 @@ export async function markdownToHwpBinary(md: string): Promise<Buffer> {
       if (run.text.length > 0 && (bold || italic)) {
         formatOps.push({
           type: 'setFormat',
-          ref: `s0.p${target.paragraphIndex}`,
+          ref: `s0.p${target.paragraphIndex + 1}`,
           format: {
             bold,
             italic,

--- a/src/markdown/to-hwp-binary.ts
+++ b/src/markdown/to-hwp-binary.ts
@@ -72,27 +72,16 @@ export async function markdownToHwpBinary(md: string): Promise<Buffer> {
   }
 
   for (const target of paragraphTargets) {
-    let charOffset = 0
-    for (const run of target.paragraph.runs) {
-      const charShape = doc.header.charShapes[run.charShapeRef]
-      const bold = charShape?.bold === true ? true : undefined
-      const italic = charShape?.italic === true ? true : undefined
-
-      if (run.text.length > 0 && (bold || italic)) {
-        formatOps.push({
-          type: 'setFormat',
-          ref: `s0.p${target.paragraphIndex + 1}`,
-          format: {
-            bold,
-            italic,
-          },
-          start: charOffset,
-          end: charOffset + run.text.length,
-        })
-      }
-
-      charOffset += run.text.length
+    const paragraphFormat = getUniformParagraphFormat(target.paragraph, doc)
+    if (!paragraphFormat) {
+      continue
     }
+
+    formatOps.push({
+      type: 'setFormat',
+      ref: `s0.p${target.paragraphIndex + 1}`,
+      format: paragraphFormat,
+    })
   }
 
   const tempPath = join(
@@ -123,4 +112,38 @@ function flattenSections(doc: HwpDocument): FlattenedItem[] {
   })
 
   return items
+}
+
+function getUniformParagraphFormat(
+  paragraph: Paragraph,
+  doc: HwpDocument,
+): { bold?: true; italic?: true } | null {
+  const nonEmptyRuns = paragraph.runs.filter((run) => run.text.length > 0)
+  if (nonEmptyRuns.length === 0) {
+    return null
+  }
+
+  let detected: { bold?: true; italic?: true } | null = null
+  for (const run of nonEmptyRuns) {
+    const charShape = doc.header.charShapes[run.charShapeRef]
+    const runFormat: { bold?: true; italic?: true } = {
+      bold: charShape?.bold === true ? true : undefined,
+      italic: charShape?.italic === true ? true : undefined,
+    }
+
+    if (!detected) {
+      detected = runFormat
+      continue
+    }
+
+    if (detected.bold !== runFormat.bold || detected.italic !== runFormat.italic) {
+      return null
+    }
+  }
+
+  if (!detected || (!detected.bold && !detected.italic)) {
+    return null
+  }
+
+  return detected
 }

--- a/src/markdown/to-hwp-binary.ts
+++ b/src/markdown/to-hwp-binary.ts
@@ -1,0 +1,3 @@
+export async function markdownToHwpBinary(_md: string): Promise<Buffer> {
+  throw new Error('MD→HWP binary conversion not yet implemented')
+}

--- a/src/markdown/to-hwp-binary.ts
+++ b/src/markdown/to-hwp-binary.ts
@@ -13,7 +13,12 @@ type FlattenedItem =
   | { type: 'table'; table: Table }
   | { type: 'sectionSeparator' }
 
-export async function markdownToHwpBinary(md: string): Promise<Buffer> {
+export type MarkdownToHwpBinaryResult = {
+  buffer: Buffer
+  doc: HwpDocument
+}
+
+export async function markdownToHwpBinary(md: string): Promise<MarkdownToHwpBinaryResult> {
   const doc = markdownToHwp(md)
 
   if (doc.sections.some((section) => section.images.length > 0)) {
@@ -59,6 +64,7 @@ export async function markdownToHwpBinary(md: string): Promise<Buffer> {
         data,
         position: 'end',
       })
+      paragraphIndex += 1
       continue
     }
 
@@ -93,7 +99,8 @@ export async function markdownToHwpBinary(md: string): Promise<Buffer> {
     const base = await createHwp({ font: '맑은 고딕', fontSize: 10 })
     await writeFile(tempPath, base)
     await editHwp(tempPath, [...structureOps, ...formatOps])
-    return await readFile(tempPath)
+    const buffer = await readFile(tempPath)
+    return { buffer, doc }
   } finally {
     await unlink(tempPath).catch(() => {})
   }

--- a/src/markdown/to-hwp.test.ts
+++ b/src/markdown/to-hwp.test.ts
@@ -105,6 +105,24 @@ describe('markdownToHwp', () => {
     expect(table.rows[1].cells[1].paragraphs[0].runs[0].text).toBe('Dev')
   })
 
+  it('preserves column alignment in GFM table cells', () => {
+    const md = '| Left | Center | Right |\n|:---|:---:|---:|\n| a | b | c |'
+    const doc = markdownToHwp(md)
+    const table = doc.sections[0].tables[0]
+
+    const leftParaShapeId = table.rows[0].cells[0].paragraphs[0].paraShapeRef
+    const centerParaShapeId = table.rows[0].cells[1].paragraphs[0].paraShapeRef
+    const rightParaShapeId = table.rows[0].cells[2].paragraphs[0].paraShapeRef
+
+    const leftParaShape = doc.header.paraShapes.find((ps) => ps.id === leftParaShapeId)
+    const centerParaShape = doc.header.paraShapes.find((ps) => ps.id === centerParaShapeId)
+    const rightParaShape = doc.header.paraShapes.find((ps) => ps.id === rightParaShapeId)
+
+    expect(leftParaShape?.align).toBe('left')
+    expect(centerParaShape?.align).toBe('center')
+    expect(rightParaShape?.align).toBe('right')
+  })
+
   it('converts unordered list items with bullet prefix', () => {
     const doc = markdownToHwp('- Item 1\n- Item 2')
 

--- a/src/markdown/to-hwp.test.ts
+++ b/src/markdown/to-hwp.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'bun:test'
+import { headingStyleName } from './heading-styles'
+import { markdownToHwp } from './to-hwp'
+
+function findStyleIdByName(doc: ReturnType<typeof markdownToHwp>, name: string): number {
+  const style = doc.header.styles.find((item) => item.name === name)
+  if (!style) {
+    throw new Error(`Style not found: ${name}`)
+  }
+
+  return style.id
+}
+
+describe('markdownToHwp', () => {
+  it('converts plain paragraph into one section with one paragraph and one run', () => {
+    const doc = markdownToHwp('Hello world')
+
+    expect(doc.sections).toHaveLength(1)
+    expect(doc.sections[0].paragraphs).toHaveLength(1)
+    expect(doc.sections[0].paragraphs[0].runs).toEqual([{ text: 'Hello world', charShapeRef: 0 }])
+  })
+
+  it('converts two markdown paragraphs into two HWP paragraphs', () => {
+    const doc = markdownToHwp('First\n\nSecond')
+
+    expect(doc.sections).toHaveLength(1)
+    expect(doc.sections[0].paragraphs).toHaveLength(2)
+    expect(doc.sections[0].paragraphs[0].runs[0].text).toBe('First')
+    expect(doc.sections[0].paragraphs[1].runs[0].text).toBe('Second')
+  })
+
+  it('marks bold text with bold char shape', () => {
+    const doc = markdownToHwp('**bold**')
+    const run = doc.sections[0].paragraphs[0].runs[0]
+    const shape = doc.header.charShapes[run.charShapeRef]
+
+    expect(run.text).toBe('bold')
+    expect(shape.bold).toBe(true)
+    expect(shape.italic).toBe(false)
+  })
+
+  it('marks italic text with italic char shape', () => {
+    const doc = markdownToHwp('*italic*')
+    const run = doc.sections[0].paragraphs[0].runs[0]
+    const shape = doc.header.charShapes[run.charShapeRef]
+
+    expect(run.text).toBe('italic')
+    expect(shape.italic).toBe(true)
+    expect(shape.bold).toBe(false)
+  })
+
+  it('marks nested strong emphasis text as bold and italic', () => {
+    const doc = markdownToHwp('***bold italic***')
+    const run = doc.sections[0].paragraphs[0].runs[0]
+    const shape = doc.header.charShapes[run.charShapeRef]
+
+    expect(run.text).toBe('bold italic')
+    expect(shape.bold).toBe(true)
+    expect(shape.italic).toBe(true)
+  })
+
+  it('drops strikethrough formatting but keeps text', () => {
+    const doc = markdownToHwp('~~strikethrough~~')
+    const run = doc.sections[0].paragraphs[0].runs[0]
+    const shape = doc.header.charShapes[run.charShapeRef]
+
+    expect(run.text).toBe('strikethrough')
+    expect(shape.bold).toBe(false)
+    expect(shape.italic).toBe(false)
+    expect(shape.underline).toBe(false)
+  })
+
+  it('maps heading level 1 to style 개요 1', () => {
+    const doc = markdownToHwp('# Heading 1')
+    const paragraph = doc.sections[0].paragraphs[0]
+    const styleId = findStyleIdByName(doc, headingStyleName(1))
+
+    expect(paragraph.styleRef).toBe(styleId)
+  })
+
+  it('maps heading level 2 to style 개요 2', () => {
+    const doc = markdownToHwp('## Heading 2')
+    const paragraph = doc.sections[0].paragraphs[0]
+    const styleId = findStyleIdByName(doc, headingStyleName(2))
+
+    expect(paragraph.styleRef).toBe(styleId)
+  })
+
+  it('converts a GFM table to one HWP table with rows and cells', () => {
+    const doc = markdownToHwp('| A | B |\n| --- | --- |\n| C | D |')
+
+    expect(doc.sections[0].tables).toHaveLength(1)
+    expect(doc.sections[0].tables[0].rows).toHaveLength(2)
+    expect(doc.sections[0].tables[0].rows[0].cells).toHaveLength(2)
+    expect(doc.sections[0].tables[0].rows[1].cells).toHaveLength(2)
+  })
+
+  it('keeps table cell text content', () => {
+    const doc = markdownToHwp('| Name | Role |\n| --- | --- |\n| Alice | Dev |')
+    const table = doc.sections[0].tables[0]
+
+    expect(table.rows[0].cells[0].paragraphs[0].runs[0].text).toBe('Name')
+    expect(table.rows[0].cells[1].paragraphs[0].runs[0].text).toBe('Role')
+    expect(table.rows[1].cells[0].paragraphs[0].runs[0].text).toBe('Alice')
+    expect(table.rows[1].cells[1].paragraphs[0].runs[0].text).toBe('Dev')
+  })
+
+  it('converts unordered list items with bullet prefix', () => {
+    const doc = markdownToHwp('- Item 1\n- Item 2')
+
+    expect(doc.sections[0].paragraphs).toHaveLength(2)
+    expect(doc.sections[0].paragraphs[0].runs[0].text).toBe('• Item 1')
+    expect(doc.sections[0].paragraphs[1].runs[0].text).toBe('• Item 2')
+  })
+
+  it('converts ordered list items with numeric prefix', () => {
+    const doc = markdownToHwp('1. First\n2. Second')
+
+    expect(doc.sections[0].paragraphs).toHaveLength(2)
+    expect(doc.sections[0].paragraphs[0].runs[0].text).toBe('1. First')
+    expect(doc.sections[0].paragraphs[1].runs[0].text).toBe('2. Second')
+  })
+
+  it('uses monospace font for inline code', () => {
+    const doc = markdownToHwp('Use `code` here')
+    const codeRun = doc.sections[0].paragraphs[0].runs.find((run) => run.text === 'code')
+
+    expect(codeRun).toBeDefined()
+    const shape = doc.header.charShapes[codeRun!.charShapeRef]
+    expect(shape.fontRef).toBe(1)
+  })
+
+  it('uses monospace font for fenced code block lines', () => {
+    const doc = markdownToHwp('```ts\nconst x = 1\nconsole.log(x)\n```')
+
+    expect(doc.sections[0].paragraphs).toHaveLength(2)
+    for (const paragraph of doc.sections[0].paragraphs) {
+      const shape = doc.header.charShapes[paragraph.runs[0].charShapeRef]
+      expect(shape.fontRef).toBe(1)
+    }
+  })
+
+  it('prefixes blockquote paragraphs with >', () => {
+    const doc = markdownToHwp('> blockquote')
+
+    expect(doc.sections[0].paragraphs[0].runs[0].text).toBe('> blockquote')
+  })
+
+  it('converts link to text plus URL suffix', () => {
+    const doc = markdownToHwp('[text](https://example.com)')
+
+    expect(doc.sections[0].paragraphs[0].runs[0].text).toBe('text (https://example.com)')
+  })
+
+  it('splits sections on thematic break', () => {
+    const doc = markdownToHwp('First\n\n---\n\nSecond')
+
+    expect(doc.sections).toHaveLength(2)
+  })
+
+  it('creates two sections for Section 1 and Section 2 around thematic break', () => {
+    const doc = markdownToHwp('Section 1\n\n---\n\nSection 2')
+
+    expect(doc.sections).toHaveLength(2)
+    expect(doc.sections[0].paragraphs[0].runs[0].text).toBe('Section 1')
+    expect(doc.sections[1].paragraphs[0].runs[0].text).toBe('Section 2')
+  })
+
+  it('includes default and monospace fonts in header', () => {
+    const doc = markdownToHwp('text')
+
+    expect(doc.header.fonts.length).toBeGreaterThanOrEqual(2)
+    expect(doc.header.fonts[0].name).toBe('맑은 고딕')
+    expect(doc.header.fonts[1].name).toBe('Courier New')
+  })
+
+  it('keeps header char shape references self-consistent', () => {
+    const doc = markdownToHwp('**bold** and `code`')
+    const maxCharShapeRef = doc.header.charShapes.length - 1
+
+    for (const section of doc.sections) {
+      for (const paragraph of section.paragraphs) {
+        for (const run of paragraph.runs) {
+          expect(run.charShapeRef).toBeGreaterThanOrEqual(0)
+          expect(run.charShapeRef).toBeLessThanOrEqual(maxCharShapeRef)
+        }
+      }
+    }
+
+    for (const style of doc.header.styles) {
+      expect(style.charShapeRef).toBeGreaterThanOrEqual(0)
+      expect(style.charShapeRef).toBeLessThanOrEqual(maxCharShapeRef)
+    }
+  })
+
+  it('includes body style and heading styles in header', () => {
+    const doc = markdownToHwp('# Title')
+    const styleNames = doc.header.styles.map((style) => style.name)
+
+    expect(styleNames).toContain('본문')
+    for (let level = 1; level <= 6; level++) {
+      expect(styleNames).toContain(headingStyleName(level))
+    }
+  })
+
+  it('captures markdown image as HWP image entry', () => {
+    const doc = markdownToHwp('![alt](./image.png)')
+
+    expect(doc.sections[0].images).toHaveLength(1)
+    expect(doc.sections[0].images[0].binDataPath).toBe('./image.png')
+    expect(doc.sections[0].images[0].format).toBe('png')
+  })
+})

--- a/src/markdown/to-hwp.ts
+++ b/src/markdown/to-hwp.ts
@@ -9,7 +9,9 @@ import type {
   Table as MdTable,
   TableCell as MdTableCell,
   TableRow as MdTableRow,
+  RootContent,
 } from 'mdast'
+import type { Node } from 'unist'
 import { remark } from 'remark'
 import remarkGfm from 'remark-gfm'
 import {
@@ -46,7 +48,7 @@ const PARA_SHAPE_RIGHT_ID = 8
 
 export function markdownToHwp(md: string): HwpDocument {
   const tree = remark().use(remarkGfm).parse(md) as Root
-  const charShapeRegistry = new CharShapeRegistry(0, 1000)
+  const charShapeRegistry = new CharShapeRegistry(0, 10)
 
   const fonts: FontFace[] = [
     { id: 0, name: '맑은 고딕' },
@@ -445,16 +447,16 @@ function appendBlockquoteParagraphs(
   }
 }
 
-function collectText(node: any): string {
+function collectText(node: Node): string {
   switch (node.type) {
     case 'text':
-      return node.value ?? ''
+      return (node as { value?: string }).value ?? ''
     case 'inlineCode':
-      return node.value ?? ''
+      return (node as { value?: string }).value ?? ''
     case 'image':
-      return node.alt ?? ''
+      return (node as { alt?: string }).alt ?? ''
     default: {
-      const childContainer = node as { children?: Array<any> }
+      const childContainer = node as { children?: Node[] }
       if (!childContainer.children) {
         return ''
       }
@@ -462,11 +464,11 @@ function collectText(node: any): string {
       let text = ''
       for (const child of childContainer.children) {
         if (child.type === 'text') {
-          text += child.value ?? ''
+          text += (child as { value?: string }).value ?? ''
         } else if (child.type === 'inlineCode') {
-          text += child.value ?? ''
+          text += (child as { value?: string }).value ?? ''
         } else if (child.type === 'image') {
-          text += child.alt ?? ''
+          text += (child as { alt?: string }).alt ?? ''
         } else if ('children' in child) {
           text += collectText(child)
         }

--- a/src/markdown/to-hwp.ts
+++ b/src/markdown/to-hwp.ts
@@ -9,7 +9,6 @@ import type {
   Table as MdTable,
   TableCell as MdTableCell,
   TableRow as MdTableRow,
-  RootContent,
 } from 'mdast'
 import type { Node } from 'unist'
 import { remark } from 'remark'

--- a/src/markdown/to-hwp.ts
+++ b/src/markdown/to-hwp.ts
@@ -41,6 +41,9 @@ type SectionAccumulator = {
   imageCount: number
 }
 
+const PARA_SHAPE_CENTER_ID = 7
+const PARA_SHAPE_RIGHT_ID = 8
+
 export function markdownToHwp(md: string): HwpDocument {
   const tree = remark().use(remarkGfm).parse(md) as Root
   const charShapeRegistry = new CharShapeRegistry(0, 1000)
@@ -51,7 +54,12 @@ export function markdownToHwp(md: string): HwpDocument {
   ]
 
   const headingInfra = createHeadingInfrastructure(0, 0, 0)
-  const paraShapes: ParaShape[] = [{ id: 0, align: 'left' }, ...headingInfra.paraShapes]
+  const paraShapes: ParaShape[] = [
+    { id: 0, align: 'left' },
+    ...headingInfra.paraShapes,
+    { id: PARA_SHAPE_CENTER_ID, align: 'center' },
+    { id: PARA_SHAPE_RIGHT_ID, align: 'right' },
+  ]
   const styles: Style[] = [
     { id: 0, name: '본문', charShapeRef: 0, paraShapeRef: 0, type: 'PARA' },
     ...headingInfra.styles,
@@ -102,12 +110,12 @@ export function markdownToHwp(md: string): HwpDocument {
         current.paragraphCount += 1
         break
       }
-      case 'table': {
-        const table = createTableFromMdast(node, sectionIndex, current.tableCount)
-        current.section.tables.push(table)
-        current.tableCount += 1
-        break
-      }
+       case 'table': {
+         const table = createTableFromMdast(node, sectionIndex, current.tableCount, node.align ?? [])
+         current.section.tables.push(table)
+         current.tableCount += 1
+         break
+       }
       case 'list': {
         appendListParagraphs(node, sectionIndex, current, charShapeRegistry, 0)
         break
@@ -287,9 +295,14 @@ function inferImageFormat(url: string): string {
   return cleanUrl.slice(dotIndex + 1).toLowerCase()
 }
 
-function createTableFromMdast(node: MdTable, sectionIndex: number, tableIndex: number): Table {
+function createTableFromMdast(
+  node: MdTable,
+  sectionIndex: number,
+  tableIndex: number,
+  align: Array<'left' | 'center' | 'right' | null>,
+): Table {
   const rows: TableRow[] = node.children.map((row, rowIndex) =>
-    createTableRowFromMdast(row, sectionIndex, tableIndex, rowIndex),
+    createTableRowFromMdast(row, sectionIndex, tableIndex, rowIndex, align),
   )
 
   return {
@@ -303,9 +316,10 @@ function createTableRowFromMdast(
   sectionIndex: number,
   tableIndex: number,
   rowIndex: number,
+  align: Array<'left' | 'center' | 'right' | null>,
 ): TableRow {
   const cells: TableCell[] = row.children.map((cell, cellIndex) =>
-    createTableCellFromMdast(cell, sectionIndex, tableIndex, rowIndex, cellIndex),
+    createTableCellFromMdast(cell, sectionIndex, tableIndex, rowIndex, cellIndex, align[cellIndex] ?? null),
   )
 
   return { cells }
@@ -317,7 +331,14 @@ function createTableCellFromMdast(
   tableIndex: number,
   rowIndex: number,
   cellIndex: number,
+  colAlign: 'left' | 'center' | 'right' | null,
 ): TableCell {
+  const paraShapeRef =
+    colAlign === 'center'
+      ? PARA_SHAPE_CENTER_ID
+      : colAlign === 'right'
+        ? PARA_SHAPE_RIGHT_ID
+        : 0
   const text = collectText(cell)
   return {
     ref: `s${sectionIndex}.t${tableIndex}.r${rowIndex}.c${cellIndex}`,
@@ -325,7 +346,7 @@ function createTableCellFromMdast(
       {
         ref: `s${sectionIndex}.p0`,
         runs: [{ text, charShapeRef: 0 }],
-        paraShapeRef: 0,
+        paraShapeRef,
         styleRef: 0,
       },
     ],

--- a/src/markdown/to-hwp.ts
+++ b/src/markdown/to-hwp.ts
@@ -1,0 +1,464 @@
+import type {
+  Blockquote,
+  Code,
+  Delete,
+  Emphasis,
+  Heading,
+  Image as MdImage,
+  InlineCode,
+  Link,
+  List,
+  ListItem,
+  Paragraph as MdParagraph,
+  PhrasingContent,
+  Root,
+  Strong,
+  Table as MdTable,
+  TableCell as MdTableCell,
+  TableRow as MdTableRow,
+  Text,
+} from 'mdast'
+import { remark } from 'remark'
+import remarkGfm from 'remark-gfm'
+import {
+  type DocumentHeader,
+  type FontFace,
+  type HwpDocument,
+  type Image,
+  type Paragraph,
+  type ParaShape,
+  type Run,
+  type Section,
+  type Style,
+  type Table,
+  type TableCell,
+  type TableRow,
+} from '@/types'
+import { CharShapeRegistry } from './charshape-registry'
+import { createHeadingInfrastructure } from './heading-styles'
+
+type InlineFlags = {
+  bold?: boolean
+  italic?: boolean
+}
+
+type SectionAccumulator = {
+  section: Section
+  paragraphCount: number
+  tableCount: number
+  imageCount: number
+}
+
+export function markdownToHwp(md: string): HwpDocument {
+  const tree = remark().use(remarkGfm).parse(md) as Root
+  const charShapeRegistry = new CharShapeRegistry(0, 1000)
+
+  const fonts: FontFace[] = [
+    { id: 0, name: '맑은 고딕' },
+    { id: 1, name: 'Courier New' },
+  ]
+
+  const headingInfra = createHeadingInfrastructure(0, 0, 0)
+  const paraShapes: ParaShape[] = [{ id: 0, align: 'left' }, ...headingInfra.paraShapes]
+  const styles: Style[] = [
+    { id: 0, name: '본문', charShapeRef: 0, paraShapeRef: 0, type: 'PARA' },
+    ...headingInfra.styles,
+  ]
+
+  const sections: Section[] = []
+  let sectionIndex = 0
+  let current = createSectionAccumulator()
+
+  const pushCurrentSection = (): void => {
+    sections.push(current.section)
+  }
+
+  const startNextSection = (): void => {
+    sectionIndex += 1
+    current = createSectionAccumulator()
+  }
+
+  for (const node of tree.children) {
+    switch (node.type) {
+      case 'thematicBreak': {
+        pushCurrentSection()
+        startNextSection()
+        break
+      }
+      case 'paragraph': {
+        const runs: Run[] = []
+        for (const child of node.children) {
+          appendRunsFromPhrasing(child, runs, charShapeRegistry, current, sectionIndex, {})
+        }
+
+        if (runs.length > 0) {
+          current.section.paragraphs.push(
+            createParagraph(sectionIndex, current.paragraphCount, runs, 0, 0),
+          )
+          current.paragraphCount += 1
+        }
+        break
+      }
+      case 'heading': {
+        const depth = Math.max(1, Math.min(6, node.depth))
+        const text = collectText(node)
+        const runs: Run[] = [{ text, charShapeRef: 0 }]
+
+        current.section.paragraphs.push(
+          createParagraph(sectionIndex, current.paragraphCount, runs, depth, depth),
+        )
+        current.paragraphCount += 1
+        break
+      }
+      case 'table': {
+        const table = createTableFromMdast(node, sectionIndex, current.tableCount)
+        current.section.tables.push(table)
+        current.tableCount += 1
+        break
+      }
+      case 'list': {
+        appendListParagraphs(node, sectionIndex, current, charShapeRegistry, 0)
+        break
+      }
+      case 'code': {
+        appendCodeParagraphs(node, sectionIndex, current, charShapeRegistry)
+        break
+      }
+      case 'blockquote': {
+        appendBlockquoteParagraphs(node, sectionIndex, current, charShapeRegistry)
+        break
+      }
+      case 'image': {
+        appendImage(node.url, sectionIndex, current)
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  pushCurrentSection()
+
+  const header: DocumentHeader = {
+    fonts,
+    charShapes: charShapeRegistry.getCharShapes(),
+    paraShapes,
+    styles,
+  }
+
+  return {
+    format: 'hwp',
+    sections,
+    header,
+  }
+}
+
+function createSectionAccumulator(): SectionAccumulator {
+  return {
+    section: {
+      paragraphs: [],
+      tables: [],
+      images: [],
+      textBoxes: [],
+    },
+    paragraphCount: 0,
+    tableCount: 0,
+    imageCount: 0,
+  }
+}
+
+function createParagraph(
+  sectionIndex: number,
+  paragraphIndex: number,
+  runs: Run[],
+  paraShapeRef: number,
+  styleRef: number,
+): Paragraph {
+  return {
+    ref: `s${sectionIndex}.p${paragraphIndex}`,
+    runs,
+    paraShapeRef,
+    styleRef,
+  }
+}
+
+function appendRunsFromPhrasing(
+  node: PhrasingContent,
+  runs: Run[],
+  registry: CharShapeRegistry,
+  current: SectionAccumulator,
+  sectionIndex: number,
+  flags: InlineFlags,
+): void {
+  switch (node.type) {
+    case 'text': {
+      const charShapeRef = registry.getRef({
+        bold: flags.bold,
+        italic: flags.italic,
+      })
+      runs.push({ text: node.value, charShapeRef })
+      break
+    }
+    case 'strong': {
+      for (const child of node.children) {
+        appendRunsFromPhrasing(child, runs, registry, current, sectionIndex, {
+          ...flags,
+          bold: true,
+        })
+      }
+      break
+    }
+    case 'emphasis': {
+      for (const child of node.children) {
+        appendRunsFromPhrasing(child, runs, registry, current, sectionIndex, {
+          ...flags,
+          italic: true,
+        })
+      }
+      break
+    }
+    case 'delete': {
+      for (const child of node.children) {
+        appendRunsFromDelete(child, runs, registry, current, sectionIndex, flags)
+      }
+      break
+    }
+    case 'inlineCode': {
+      const charShapeRef = registry.getRef({
+        bold: flags.bold,
+        italic: flags.italic,
+        fontRef: 1,
+      })
+      runs.push({ text: node.value, charShapeRef })
+      break
+    }
+    case 'link': {
+      const linkText = collectText(node)
+      const charShapeRef = registry.getRef({
+        bold: flags.bold,
+        italic: flags.italic,
+      })
+      runs.push({ text: `${linkText} (${node.url})`, charShapeRef })
+      break
+    }
+    case 'image': {
+      appendImage(node.url, sectionIndex, current)
+      break
+    }
+    default:
+      break
+  }
+}
+
+function appendRunsFromDelete(
+  node: Delete['children'][number],
+  runs: Run[],
+  registry: CharShapeRegistry,
+  current: SectionAccumulator,
+  sectionIndex: number,
+  flags: InlineFlags,
+): void {
+  if (node.type === 'text') {
+    const charShapeRef = registry.getRef({
+      bold: flags.bold,
+      italic: flags.italic,
+    })
+    runs.push({ text: node.value, charShapeRef })
+    return
+  }
+
+  if (node.type === 'emphasis' || node.type === 'strong' || node.type === 'inlineCode' || node.type === 'link' || node.type === 'image') {
+    appendRunsFromPhrasing(node, runs, registry, current, sectionIndex, flags)
+  }
+}
+
+function appendImage(url: string, sectionIndex: number, current: SectionAccumulator): void {
+  const image: Image = {
+    ref: `s${sectionIndex}.img${current.imageCount}`,
+    binDataPath: url,
+    width: 0,
+    height: 0,
+    format: inferImageFormat(url),
+  }
+
+  current.section.images.push(image)
+  current.imageCount += 1
+}
+
+function inferImageFormat(url: string): string {
+  const cleanUrl = url.split('#')[0].split('?')[0]
+  const dotIndex = cleanUrl.lastIndexOf('.')
+  if (dotIndex < 0 || dotIndex === cleanUrl.length - 1) {
+    return ''
+  }
+
+  return cleanUrl.slice(dotIndex + 1).toLowerCase()
+}
+
+function createTableFromMdast(node: MdTable, sectionIndex: number, tableIndex: number): Table {
+  const rows: TableRow[] = node.children.map((row, rowIndex) =>
+    createTableRowFromMdast(row, sectionIndex, tableIndex, rowIndex),
+  )
+
+  return {
+    ref: `s${sectionIndex}.t${tableIndex}`,
+    rows,
+  }
+}
+
+function createTableRowFromMdast(
+  row: MdTableRow,
+  sectionIndex: number,
+  tableIndex: number,
+  rowIndex: number,
+): TableRow {
+  const cells: TableCell[] = row.children.map((cell, cellIndex) =>
+    createTableCellFromMdast(cell, sectionIndex, tableIndex, rowIndex, cellIndex),
+  )
+
+  return { cells }
+}
+
+function createTableCellFromMdast(
+  cell: MdTableCell,
+  sectionIndex: number,
+  tableIndex: number,
+  rowIndex: number,
+  cellIndex: number,
+): TableCell {
+  const text = collectText(cell)
+  return {
+    ref: `s${sectionIndex}.t${tableIndex}.r${rowIndex}.c${cellIndex}`,
+    paragraphs: [
+      {
+        ref: `s${sectionIndex}.p0`,
+        runs: [{ text, charShapeRef: 0 }],
+        paraShapeRef: 0,
+        styleRef: 0,
+      },
+    ],
+    colSpan: 1,
+    rowSpan: 1,
+  }
+}
+
+function appendListParagraphs(
+  list: List,
+  sectionIndex: number,
+  current: SectionAccumulator,
+  registry: CharShapeRegistry,
+  level: number,
+): void {
+  list.children.forEach((item, itemIndex) => {
+    appendListItemParagraph(item, list, itemIndex, sectionIndex, current, registry, level)
+  })
+}
+
+function appendListItemParagraph(
+  item: ListItem,
+  list: List,
+  itemIndex: number,
+  sectionIndex: number,
+  current: SectionAccumulator,
+  registry: CharShapeRegistry,
+  level: number,
+): void {
+  const indentPrefix = '  '.repeat(level)
+  const marker = list.ordered ? `${itemIndex + 1}. ` : '• '
+  const contentNodes = item.children.filter((child) => child.type !== 'list')
+  const itemText = contentNodes.map((child) => collectText(child)).join(' ').trim()
+
+  if (itemText.length > 0) {
+    const charShapeRef = registry.getRef()
+    const paragraph = createParagraph(
+      sectionIndex,
+      current.paragraphCount,
+      [{ text: `${indentPrefix}${marker}${itemText}`, charShapeRef }],
+      0,
+      0,
+    )
+    current.section.paragraphs.push(paragraph)
+    current.paragraphCount += 1
+  }
+
+  for (const child of item.children) {
+    if (child.type === 'list') {
+      appendListParagraphs(child, sectionIndex, current, registry, level + 1)
+    }
+  }
+}
+
+function appendCodeParagraphs(
+  code: Code,
+  sectionIndex: number,
+  current: SectionAccumulator,
+  registry: CharShapeRegistry,
+): void {
+  const codeShapeRef = registry.getRef({ fontRef: 1 })
+  const lines = code.value.split('\n')
+  for (const line of lines) {
+    const paragraph = createParagraph(
+      sectionIndex,
+      current.paragraphCount,
+      [{ text: line, charShapeRef: codeShapeRef }],
+      0,
+      0,
+    )
+    current.section.paragraphs.push(paragraph)
+    current.paragraphCount += 1
+  }
+}
+
+function appendBlockquoteParagraphs(
+  blockquote: Blockquote,
+  sectionIndex: number,
+  current: SectionAccumulator,
+  registry: CharShapeRegistry,
+): void {
+  for (const child of blockquote.children) {
+    if (child.type === 'paragraph') {
+      const text = collectText(child)
+      const charShapeRef = registry.getRef()
+      const paragraph = createParagraph(
+        sectionIndex,
+        current.paragraphCount,
+        [{ text: `> ${text}`, charShapeRef }],
+        0,
+        0,
+      )
+      current.section.paragraphs.push(paragraph)
+      current.paragraphCount += 1
+    }
+  }
+}
+
+function collectText(node: any): string {
+  switch (node.type) {
+    case 'text':
+      return node.value ?? ''
+    case 'inlineCode':
+      return node.value ?? ''
+    case 'image':
+      return node.alt ?? ''
+    default: {
+      const childContainer = node as { children?: Array<any> }
+      if (!childContainer.children) {
+        return ''
+      }
+
+      let text = ''
+      for (const child of childContainer.children) {
+        if (child.type === 'text') {
+          text += child.value ?? ''
+        } else if (child.type === 'inlineCode') {
+          text += child.value ?? ''
+        } else if (child.type === 'image') {
+          text += child.alt ?? ''
+        } else if ('children' in child) {
+          text += collectText(child)
+        }
+      }
+      return text
+    }
+  }
+}

--- a/src/markdown/to-hwp.ts
+++ b/src/markdown/to-hwp.ts
@@ -2,21 +2,13 @@ import type {
   Blockquote,
   Code,
   Delete,
-  Emphasis,
-  Heading,
-  Image as MdImage,
-  InlineCode,
-  Link,
   List,
   ListItem,
-  Paragraph as MdParagraph,
   PhrasingContent,
   Root,
-  Strong,
   Table as MdTable,
   TableCell as MdTableCell,
   TableRow as MdTableRow,
-  Text,
 } from 'mdast'
 import { remark } from 'remark'
 import remarkGfm from 'remark-gfm'

--- a/src/markdown/to-hwp.ts
+++ b/src/markdown/to-hwp.ts
@@ -345,7 +345,7 @@ function createTableCellFromMdast(
     ref: `s${sectionIndex}.t${tableIndex}.r${rowIndex}.c${cellIndex}`,
     paragraphs: [
       {
-        ref: `s${sectionIndex}.p0`,
+        ref: `s${sectionIndex}.t${tableIndex}.r${rowIndex}.c${cellIndex}.p0`,
         runs: [{ text, charShapeRef: 0 }],
         paraShapeRef,
         styleRef: 0,

--- a/src/markdown/to-markdown.test.ts
+++ b/src/markdown/to-markdown.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'bun:test'
+import type {
+  CharShape,
+  HwpDocument,
+  Paragraph,
+  ParaShape,
+  Section,
+  Style,
+  Table,
+} from '@/types'
+import { hwpToMarkdown } from './to-markdown'
+
+function makeDoc(
+  sections: Section[],
+  charShapes: CharShape[] = [],
+  paraShapes: ParaShape[] = [],
+  styles: Style[] = []
+): HwpDocument {
+  return {
+    format: 'hwpx',
+    sections,
+    header: { fonts: [], charShapes, paraShapes, styles },
+  }
+}
+
+function makePara(
+  text: string,
+  charShapeRef = 0,
+  paraShapeRef = 0,
+  styleRef = 0
+): Paragraph {
+  return {
+    ref: 's0.p0',
+    runs: text ? [{ text, charShapeRef }] : [],
+    paraShapeRef,
+    styleRef,
+  }
+}
+
+function makeSection(paragraphs: Paragraph[] = []): Section {
+  return {
+    paragraphs,
+    tables: [],
+    images: [],
+    textBoxes: [],
+  }
+}
+
+describe('hwpToMarkdown', () => {
+  it('converts plain text paragraph', () => {
+    const doc = makeDoc([makeSection([makePara('Hello world')])])
+
+    expect(hwpToMarkdown(doc)).toBe('Hello world')
+  })
+
+  it('separates multiple paragraphs with blank lines', () => {
+    const doc = makeDoc([
+      makeSection([makePara('First paragraph'), makePara('Second paragraph')]),
+    ])
+
+    expect(hwpToMarkdown(doc)).toBe('First paragraph\n\nSecond paragraph')
+  })
+
+  it('keeps empty paragraph as a blank line', () => {
+    const doc = makeDoc([
+      makeSection([makePara('Before'), makePara(''), makePara('After')]),
+    ])
+
+    expect(hwpToMarkdown(doc)).toBe('Before\n\n\n\nAfter')
+  })
+
+  it('applies bold formatting', () => {
+    const charShapes: CharShape[] = [
+      {
+        id: 0,
+        fontRef: 0,
+        fontSize: 10,
+        bold: true,
+        italic: false,
+        underline: false,
+        color: '#000000',
+      },
+    ]
+    const doc = makeDoc([makeSection([makePara('Bold text')])], charShapes)
+
+    expect(hwpToMarkdown(doc)).toBe('**Bold text**')
+  })
+
+  it('applies italic formatting', () => {
+    const charShapes: CharShape[] = [
+      {
+        id: 0,
+        fontRef: 0,
+        fontSize: 10,
+        bold: false,
+        italic: true,
+        underline: false,
+        color: '#000000',
+      },
+    ]
+    const doc = makeDoc([makeSection([makePara('Italic text')])], charShapes)
+
+    expect(hwpToMarkdown(doc)).toBe('*Italic text*')
+  })
+
+  it('applies bold and italic formatting together', () => {
+    const charShapes: CharShape[] = [
+      {
+        id: 0,
+        fontRef: 0,
+        fontSize: 10,
+        bold: true,
+        italic: true,
+        underline: false,
+        color: '#000000',
+      },
+    ]
+    const doc = makeDoc([makeSection([makePara('Strong emphasis')])], charShapes)
+
+    expect(hwpToMarkdown(doc)).toBe('***Strong emphasis***')
+  })
+
+  it('converts mixed runs with inline formatting', () => {
+    const section = makeSection([
+      {
+        ref: 's0.p0',
+        paraShapeRef: 0,
+        styleRef: 0,
+        runs: [
+          { text: 'plain ', charShapeRef: 0 },
+          { text: 'bold', charShapeRef: 1 },
+          { text: ' and ', charShapeRef: 0 },
+          { text: 'italic', charShapeRef: 2 },
+          { text: ' plus ', charShapeRef: 0 },
+          { text: 'both', charShapeRef: 3 },
+        ],
+      },
+    ])
+    const charShapes: CharShape[] = [
+      {
+        id: 0,
+        fontRef: 0,
+        fontSize: 10,
+        bold: false,
+        italic: false,
+        underline: false,
+        color: '#000000',
+      },
+      {
+        id: 1,
+        fontRef: 0,
+        fontSize: 10,
+        bold: true,
+        italic: false,
+        underline: false,
+        color: '#000000',
+      },
+      {
+        id: 2,
+        fontRef: 0,
+        fontSize: 10,
+        bold: false,
+        italic: true,
+        underline: false,
+        color: '#000000',
+      },
+      {
+        id: 3,
+        fontRef: 0,
+        fontSize: 10,
+        bold: true,
+        italic: true,
+        underline: false,
+        color: '#000000',
+      },
+    ]
+    const doc = makeDoc([section], charShapes)
+
+    expect(hwpToMarkdown(doc)).toBe(
+      'plain **bold** and *italic* plus ***both***'
+    )
+  })
+
+  it('drops underline, color, and font size from markdown output', () => {
+    const charShapes: CharShape[] = [
+      {
+        id: 0,
+        fontRef: 0,
+        fontSize: 22,
+        bold: false,
+        italic: false,
+        underline: true,
+        color: '#ff0000',
+      },
+    ]
+    const doc = makeDoc([makeSection([makePara('Styled text')])], charShapes)
+
+    expect(hwpToMarkdown(doc)).toBe('Styled text')
+  })
+
+  it('renders heading level 1 with # prefix', () => {
+    const para = makePara('Title', 0, 0, 1)
+    const styles: Style[] = [
+      { id: 1, name: 'Heading 1', charShapeRef: 0, paraShapeRef: 0 },
+    ]
+    const doc = makeDoc([makeSection([para])], [], [], styles)
+
+    expect(hwpToMarkdown(doc)).toBe('# Title')
+  })
+
+  it('renders heading level 2 with ## prefix', () => {
+    const para = makePara('Subtitle', 0, 0, 1)
+    const styles: Style[] = [
+      { id: 1, name: 'Heading 2', charShapeRef: 0, paraShapeRef: 0 },
+    ]
+    const doc = makeDoc([makeSection([para])], [], [], styles)
+
+    expect(hwpToMarkdown(doc)).toBe('## Subtitle')
+  })
+
+  it('detects heading through style name "개요 1"', () => {
+    const para = makePara('Korean heading', 0, 0, 7)
+    const styles: Style[] = [
+      { id: 7, name: '개요 1', charShapeRef: 0, paraShapeRef: 0 },
+    ]
+    const doc = makeDoc([makeSection([para])], [], [], styles)
+
+    expect(hwpToMarkdown(doc)).toBe('# Korean heading')
+  })
+
+  it('detects heading through paraShape.headingLevel', () => {
+    const para = makePara('Shape heading', 0, 5, 1)
+    const paraShapes: ParaShape[] = [{ id: 5, align: 'left', headingLevel: 3 }]
+    const styles: Style[] = [
+      { id: 1, name: 'Normal', charShapeRef: 0, paraShapeRef: 5 },
+    ]
+    const doc = makeDoc([makeSection([para])], [], paraShapes, styles)
+
+    expect(hwpToMarkdown(doc)).toBe('### Shape heading')
+  })
+
+  it('renders 2x2 table in GFM format', () => {
+    const table: Table = {
+      ref: 's0.t0',
+      rows: [
+        {
+          cells: [
+            {
+              ref: 's0.t0.r0.c0',
+              paragraphs: [makePara('A')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+            {
+              ref: 's0.t0.r0.c1',
+              paragraphs: [makePara('B')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+        },
+        {
+          cells: [
+            {
+              ref: 's0.t0.r1.c0',
+              paragraphs: [makePara('1')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+            {
+              ref: 's0.t0.r1.c1',
+              paragraphs: [makePara('2')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+        },
+      ],
+    }
+    const doc = makeDoc([{ ...makeSection(), tables: [table] }])
+
+    expect(hwpToMarkdown(doc)).toBe('| A | B |\n|---|---|\n| 1 | 2 |')
+  })
+
+  it('uses correct header separator count based on columns', () => {
+    const table: Table = {
+      ref: 's0.t0',
+      rows: [
+        {
+          cells: [
+            {
+              ref: 's0.t0.r0.c0',
+              paragraphs: [makePara('A')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+            {
+              ref: 's0.t0.r0.c1',
+              paragraphs: [makePara('B')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+            {
+              ref: 's0.t0.r0.c2',
+              paragraphs: [makePara('C')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+        },
+      ],
+    }
+    const doc = makeDoc([{ ...makeSection(), tables: [table] }])
+
+    expect(hwpToMarkdown(doc)).toBe('| A | B | C |\n|---|---|---|')
+  })
+
+  it('joins multi-paragraph table cell content with spaces', () => {
+    const table: Table = {
+      ref: 's0.t0',
+      rows: [
+        {
+          cells: [
+            {
+              ref: 's0.t0.r0.c0',
+              paragraphs: [makePara('Header')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+        },
+        {
+          cells: [
+            {
+              ref: 's0.t0.r1.c0',
+              paragraphs: [makePara('Hello'), makePara('World')],
+              colSpan: 1,
+              rowSpan: 1,
+            },
+          ],
+        },
+      ],
+    }
+    const doc = makeDoc([{ ...makeSection(), tables: [table] }])
+
+    expect(hwpToMarkdown(doc)).toBe('| Header |\n|---|\n| Hello World |')
+  })
+
+  it('renders image as markdown image reference', () => {
+    const doc = makeDoc([
+      {
+        ...makeSection(),
+        images: [
+          {
+            ref: 's0.i0',
+            binDataPath: 'BinData/image1.png',
+            width: 640,
+            height: 480,
+            format: 'png',
+          },
+        ],
+      },
+    ])
+
+    expect(hwpToMarkdown(doc)).toBe('![](BinData/image1.png)')
+  })
+
+  it('renders text box paragraphs as regular paragraphs', () => {
+    const doc = makeDoc([
+      {
+        ...makeSection(),
+        textBoxes: [
+          {
+            ref: 's0.tb0',
+            paragraphs: [makePara('In text box'), makePara('Second line')],
+          },
+        ],
+      },
+    ])
+
+    expect(hwpToMarkdown(doc)).toBe('In text box\n\nSecond line')
+  })
+
+  it('separates two sections with thematic break', () => {
+    const doc = makeDoc([
+      makeSection([makePara('Section 1')]),
+      makeSection([makePara('Section 2')]),
+    ])
+
+    expect(hwpToMarkdown(doc)).toBe('Section 1\n\n---\n\nSection 2')
+  })
+
+  it('uses two thematic breaks for three sections', () => {
+    const doc = makeDoc([
+      makeSection([makePara('One')]),
+      makeSection([makePara('Two')]),
+      makeSection([makePara('Three')]),
+    ])
+
+    expect(hwpToMarkdown(doc)).toBe('One\n\n---\n\nTwo\n\n---\n\nThree')
+  })
+})

--- a/src/markdown/to-markdown.ts
+++ b/src/markdown/to-markdown.ts
@@ -1,0 +1,133 @@
+import type {
+  CharShape,
+  DocumentHeader,
+  HwpDocument,
+  Paragraph,
+  Section,
+  Table,
+  TableCell,
+  TableRow,
+} from '@/types'
+import { getHeadingLevel } from './heading-styles'
+
+export function hwpToMarkdown(doc: HwpDocument): string {
+  const sections = doc.sections.map((section) => convertSection(section, doc.header))
+  return sections.join('\n\n---\n\n')
+}
+
+function convertSection(section: Section, header: DocumentHeader): string {
+  const blocks: string[] = []
+
+  for (const paragraph of section.paragraphs) {
+    blocks.push(convertParagraph(paragraph, header))
+  }
+
+  for (const image of section.images) {
+    blocks.push(`![](${image.binDataPath})`)
+  }
+
+  for (const textBox of section.textBoxes) {
+    for (const paragraph of textBox.paragraphs) {
+      blocks.push(convertParagraph(paragraph, header))
+    }
+  }
+
+  for (const table of section.tables) {
+    blocks.push(convertTable(table, header))
+  }
+
+  return blocks.join('\n\n')
+}
+
+function convertParagraph(paragraph: Paragraph, header: DocumentHeader): string {
+  const text = convertParagraphText(paragraph, header)
+  if (text.length === 0) {
+    return ''
+  }
+
+  const headingLevel = getHeadingLevel(
+    paragraph,
+    header.styles,
+    header.paraShapes
+  )
+  if (headingLevel === null) {
+    return text
+  }
+
+  const normalizedHeadingLevel = Math.max(1, Math.min(headingLevel, 6))
+  return `${'#'.repeat(normalizedHeadingLevel)} ${text}`
+}
+
+function convertParagraphText(paragraph: Paragraph, header: DocumentHeader): string {
+  return paragraph.runs
+    .map((run) => formatRunText(run.text, resolveCharShape(run.charShapeRef, header)))
+    .filter((text) => text.length > 0)
+    .join('')
+}
+
+function resolveCharShape(
+  charShapeRef: number,
+  header: DocumentHeader
+): CharShape | undefined {
+  return (
+    header.charShapes.find((charShape) => charShape.id === charShapeRef) ??
+    header.charShapes[charShapeRef]
+  )
+}
+
+function formatRunText(text: string, charShape?: CharShape): string {
+  if (text.length === 0) {
+    return ''
+  }
+
+  if (!charShape) {
+    return text
+  }
+
+  if (charShape.bold && charShape.italic) {
+    return `***${text}***`
+  }
+
+  if (charShape.bold) {
+    return `**${text}**`
+  }
+
+  if (charShape.italic) {
+    return `*${text}*`
+  }
+
+  return text
+}
+
+function convertTable(table: Table, header: DocumentHeader): string {
+  if (table.rows.length === 0) {
+    return ''
+  }
+
+  const headerRow = table.rows[0]
+  const lines = [rowToMarkdown(headerRow, header)]
+  lines.push(separatorRow(headerRow))
+
+  for (const row of table.rows.slice(1)) {
+    lines.push(rowToMarkdown(row, header))
+  }
+
+  return lines.join('\n')
+}
+
+function rowToMarkdown(row: TableRow, header: DocumentHeader): string {
+  const content = row.cells.map((cell) => convertCell(cell, header)).join(' | ')
+  return `| ${content} |`
+}
+
+function separatorRow(headerRow: TableRow): string {
+  const separators = headerRow.cells.map(() => '---').join('|')
+  return `|${separators}|`
+}
+
+function convertCell(cell: TableCell, header: DocumentHeader): string {
+  return cell.paragraphs
+    .map((paragraph) => convertParagraphText(paragraph, header))
+    .filter((text) => text.length > 0)
+    .join(' ')
+}

--- a/src/markdown/to-markdown.ts
+++ b/src/markdown/to-markdown.ts
@@ -106,7 +106,7 @@ function convertTable(table: Table, header: DocumentHeader): string {
 
   const headerRow = table.rows[0]
   const lines = [rowToMarkdown(headerRow, header)]
-  lines.push(separatorRow(headerRow))
+  lines.push(separatorRow(headerRow, header))
 
   for (const row of table.rows.slice(1)) {
     lines.push(rowToMarkdown(row, header))
@@ -120,8 +120,19 @@ function rowToMarkdown(row: TableRow, header: DocumentHeader): string {
   return `| ${content} |`
 }
 
-function separatorRow(headerRow: TableRow): string {
-  const separators = headerRow.cells.map(() => '---').join('|')
+function separatorRow(headerRow: TableRow, header: DocumentHeader): string {
+  const separators = headerRow.cells
+    .map((cell) => {
+      const paraShapeRef = cell.paragraphs[0]?.paraShapeRef ?? 0
+      const paraShape =
+        header.paraShapes.find((ps) => ps.id === paraShapeRef) ?? header.paraShapes[paraShapeRef]
+      const align = paraShape?.align
+      if (align === 'center') return ':---:'
+      if (align === 'right') return '---:'
+      if (align === 'left') return ':---'
+      return '---'
+    })
+    .join('|')
   return `|${separators}|`
 }
 

--- a/src/markdown/to-markdown.ts
+++ b/src/markdown/to-markdown.ts
@@ -141,4 +141,5 @@ function convertCell(cell: TableCell, header: DocumentHeader): string {
     .map((paragraph) => convertParagraphText(paragraph, header))
     .filter((text) => text.length > 0)
     .join(' ')
+    .replaceAll('|', '\\|')
 }


### PR DESCRIPTION
## Summary

- Add bidirectional Markdown ↔ HWP/HWPX conversion to the `convert` command, auto-detecting direction from file extensions.
- Support all 4 directions: `md→hwpx`, `md→hwp`, `hwp→md`, `hwpx→md`.
- Embed local images in MD→HWPX and extract images in HWPX→MD.

## New Files

| File | Purpose |
|------|---------|
| `src/markdown/to-markdown.ts` | HwpDocument → Markdown string (headings, bold/italic, tables, images, multi-section). |
| `src/markdown/to-hwp.ts` | Markdown string → HwpDocument via remark/mdast parsing. |
| `src/markdown/to-hwp-binary.ts` | Markdown → HWP binary via EditOperations (create + addParagraph/addTable/setFormat). |
| `src/markdown/charshape-registry.ts` | CharShape deduplication for inline formatting combinations. |
| `src/markdown/heading-styles.ts` | Heading level ↔ Korean style name mapping ("개요 1"–"개요 7"). |
| `src/markdown/image-handler.ts` | Image embed (MD→HWPX), extract (HWPX→MD), and path resolution. |
| `e2e/markdown-roundtrip.test.ts` | Round-trip E2E tests (MD→HWPX→MD, MD→HWP→MD, multi-section). |
| `e2e/markdown-convert.test.ts` | Fixture-based E2E tests with real Korean legal documents. |

## Changed Files

| File | Change |
|------|--------|
| `src/commands/convert.ts` | Extend with MD direction detection, image wiring, section XML generation. |
| `src/cli.ts` | Add `--images-dir` option to convert command. |
| `src/formats/hwpx/section-parser.ts` | Fix: `trimValues: false` + numeric text preservation (correctness bug). |

## Known Limitations (by design)

- **HWP binary**: Mixed inline formatting (bold+italic in same paragraph) applies uniform paragraph-level format only.
- **HWP binary**: Multi-section flattened to single section, table alignment ignored.
- **Lossy elements**: Code→monospace, blockquote→">" prefix, link→"text (url)", HR→section boundary.
- **Rich format loss**: Colors, font sizes, underline silently dropped in HWP→MD direction.

## Testing

- `bun test src/` — 717 pass, 0 fail.
- `bun test e2e/markdown-roundtrip.test.ts e2e/markdown-convert.test.ts` — 13 pass, 0 fail.
- `bun run typecheck` — clean.
- `bun run lint` — clean (2 pre-existing warnings in `reader.ts`).
- `bun run build` — success.
- Backward compatible: existing `hwpilot convert legacy.hwp output.hwpx` still works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bidirectional Markdown ↔ HWP/HWPX conversion to the `convert` command with auto-detection from file extensions and image handling. Supports all directions without breaking existing HWP→HWPX flows.

- **New Features**
  - Auto-detects direction from extensions; supports `md→hwpx`, `md→hwp`, `hwp→md`, `hwpx→md`.
  - Embeds local images in `md→hwpx`; extracts images in `hwpx→md`.
  - Adds `--images-dir` for where extracted images are saved.
  - Converts headings, tables, images, and multi-section documents.

- **Bug Fixes**
  - Preserves whitespace and numeric text in HWPX section parsing.
  - Escapes pipes in Markdown table cells and uses cell-scoped paragraph refs to avoid collisions.
  - Eliminates double-parse in `convert`; fixes table paragraph indexing and section stats.

<sup>Written for commit 4615e6ac6a8bb5c6e0f79417c45f65baba8a319e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

