### PR TITLE
fix(validator): decode FileHeader properties flags and parse FILEVERSION

### DIFF
--- a/src/formats/hwp/validator.test.ts
+++ b/src/formats/hwp/validator.test.ts
@@ -96,6 +96,131 @@ describe('validateHwp', () => {
       expect(getCheckMessage(result, 'cfb_structure')).toContain('Password-protected')
     })
 
+    it('fails on distribution document (properties1 bit 2)', async () => {
+      const filePath = await writeTempHwp(await createTestHwpBinary({ paragraphs: ['hello'] }), 'validator-a-distribution')
+
+      await patchFileHeader(filePath, (header) => {
+        const flags = header.readUInt32LE(36)
+        header.writeUInt32LE(flags | 0x4, 36)
+      })
+
+      const result = await validateHwp(filePath)
+
+      expect(result.valid).toBe(false)
+      expect(getCheckStatus(result, 'cfb_structure')).toBe('fail')
+      expect(getCheckMessage(result, 'cfb_structure')).toContain('Distribution documents')
+    })
+
+    it('fails on DRM document (properties1 bit 4)', async () => {
+      const filePath = await writeTempHwp(await createTestHwpBinary({ paragraphs: ['hello'] }), 'validator-a-drm')
+
+      await patchFileHeader(filePath, (header) => {
+        const flags = header.readUInt32LE(36)
+        header.writeUInt32LE(flags | 0x10, 36)
+      })
+
+      const result = await validateHwp(filePath)
+
+      expect(result.valid).toBe(false)
+      expect(getCheckStatus(result, 'cfb_structure')).toBe('fail')
+      expect(getCheckMessage(result, 'cfb_structure')).toContain('DRM-protected files')
+    })
+
+    it('fails on cert-DRM document (properties1 bit 10)', async () => {
+      const filePath = await writeTempHwp(await createTestHwpBinary({ paragraphs: ['hello'] }), 'validator-a-cert-drm')
+
+      await patchFileHeader(filePath, (header) => {
+        const flags = header.readUInt32LE(36)
+        header.writeUInt32LE(flags | 0x400, 36)
+      })
+
+      const result = await validateHwp(filePath)
+
+      expect(result.valid).toBe(false)
+      expect(getCheckStatus(result, 'cfb_structure')).toBe('fail')
+      expect(getCheckMessage(result, 'cfb_structure')).toContain('DRM-protected files')
+    })
+
+    it('warns on track-change document (properties1 bit 14)', async () => {
+      const filePath = await writeTempHwp(await createTestHwpBinary({ paragraphs: ['hello'] }), 'validator-a-track-changes')
+
+      await patchFileHeader(filePath, (header) => {
+        const flags = header.readUInt32LE(36)
+        header.writeUInt32LE(flags | 0x4000, 36)
+      })
+
+      const result = await validateHwp(filePath)
+
+      expect(result.valid).toBe(true)
+      expect(getCheckStatus(result, 'cfb_structure')).toBe('pass')
+      expect(getCheckStatus(result, 'document_properties')).toBe('warn')
+      expect(getCheckMessage(result, 'document_properties')).toContain('track changes enabled')
+    })
+
+    it('surfaces property flags in details', async () => {
+      const filePath = await writeTempHwp(
+        await createTestHwpBinary({ paragraphs: ['hello'], compressed: true }),
+        'validator-a-flag-details',
+      )
+
+      await patchFileHeader(filePath, (header) => {
+        const flags = header.readUInt32LE(36)
+        header.writeUInt32LE(flags | 0x8 | 0x40 | 0x80 | 0x800 | 0x8000 | 0x10000 | 0x20000, 36)
+        header.writeUInt32LE(0x12345678, 40)
+      })
+
+      const result = await validateHwp(filePath)
+      const cfbStructure = getCheck(result, 'cfb_structure')
+
+      expect(cfbStructure?.details).toMatchObject({
+        properties2: 0x12345678,
+        compressed: true,
+        hasScripts: true,
+        hasDocHistory: true,
+        hasSignature: true,
+        ccl: true,
+        kogl: true,
+        hasVideo: true,
+        hasTocField: true,
+      })
+    })
+
+    it('parses version 5.0.3.5', async () => {
+      const filePath = await writeTempHwp(await createTestHwpBinary({ paragraphs: ['hello'] }), 'validator-a-version-5035')
+
+      await patchFileHeader(filePath, (header) => {
+        header.writeUInt32LE(0x05000305, 32)
+      })
+
+      const result = await validateHwp(filePath)
+      const cfbStructure = getCheck(result, 'cfb_structure')
+
+      expect(getCheckStatus(result, 'schema_version')).toBe('pass')
+      expect(cfbStructure?.details).toMatchObject({
+        version: {
+          major: 5,
+          minor: 0,
+          micro: 3,
+          build: 5,
+          raw: 0x05000305,
+        },
+      })
+    })
+
+    it('fails on non-5.x document', async () => {
+      const filePath = await writeTempHwp(await createTestHwpBinary({ paragraphs: ['hello'] }), 'validator-a-version-6x')
+
+      await patchFileHeader(filePath, (header) => {
+        header.writeUInt32LE(0x06000305, 32)
+      })
+
+      const result = await validateHwp(filePath)
+
+      expect(result.valid).toBe(false)
+      expect(getCheckStatus(result, 'schema_version')).toBe('fail')
+      expect(getCheckMessage(result, 'schema_version')).toContain('Unsupported HWP schema version 6.0.3.5')
+    })
+
     it('rejects file with missing DocInfo', async () => {
       const fileHeader = getEntryContent(CFB.read(createTestHwpCfb(), { type: 'buffer' }), '/FileHeader')
       const section0 = await getSection0FromValidFixture()
@@ -901,6 +1026,25 @@ describe('validateHwp', () => {
       expect(getCheckStatus(result, 'table_structure')).toBe('pass')
     })
   })
+
+  describe('Section I — Layer 9: Empty Paragraph Text', () => {
+    it('fails when an empty paragraph contains only the paragraph-end marker', async () => {
+      const paraHeader = Buffer.alloc(24)
+      paraHeader.writeUInt32LE(0x80000001, 0)
+
+      const section0 = Buffer.concat([
+        buildRecord(TAG.PARA_HEADER, 0, paraHeader),
+        buildRecord(TAG.PARA_TEXT, 1, Buffer.from([0x0d, 0x00])),
+      ])
+
+      const filePath = await writeTempHwp(await buildHwpWithCustomSection0(section0), 'validator-i-empty-paragraph-text')
+      const result = await validateHwp(filePath)
+
+      expect(getCheckStatus(result, 'empty_paragraph_text')).toBe('fail')
+      expect(getCheckMessage(result, 'empty_paragraph_text')).toContain('paragraph-end marker (0x000D)')
+      expect(getCheckMessage(result, 'empty_paragraph_text')).toContain('non-minimal encoding')
+    })
+  })
 })
 
 function tmpPath(name: string): string {
@@ -1063,11 +1207,13 @@ function getEntryContent(cfb: CFB.CFB$Container, path: string): Buffer {
 }
 
 function getCheckStatus(result: Awaited<ReturnType<typeof validateHwp>>, checkName: string) {
-  const check = result.checks.find((item) => item.name === checkName)
-  return check?.status
+  return getCheck(result, checkName)?.status
 }
 
 function getCheckMessage(result: Awaited<ReturnType<typeof validateHwp>>, checkName: string) {
-  const check = result.checks.find((item) => item.name === checkName)
-  return check?.message ?? ''
+  return getCheck(result, checkName)?.message ?? ''
+}
+
+function getCheck(result: Awaited<ReturnType<typeof validateHwp>>, checkName: string) {
+  return result.checks.find((item) => item.name === checkName)
 }

--- a/src/sdk/formats/hwp/validator.ts
+++ b/src/sdk/formats/hwp/validator.ts
@@ -39,6 +39,25 @@ type CfbRoot = {
   FileIndex?: Array<{ name: string; content?: Uint8Array }>
 }
 
+export const HWP_PROP_COMPRESSED = 0x00000001
+export const HWP_PROP_ENCRYPTED = 0x00000002
+export const HWP_PROP_DISTRIBUTION = 0x00000004
+export const HWP_PROP_HAS_SCRIPTS = 0x00000008
+export const HWP_PROP_DRM = 0x00000010
+export const HWP_PROP_HAS_XMLTEMPLATE = 0x00000020
+export const HWP_PROP_HAS_DOCHISTORY = 0x00000040
+export const HWP_PROP_HAS_SIGNATURE = 0x00000080
+export const HWP_PROP_CERT_ENCRYPTED = 0x00000100
+export const HWP_PROP_SIGN_PREVIEW = 0x00000200
+export const HWP_PROP_CERT_DRM = 0x00000400
+export const HWP_PROP_CCL = 0x00000800
+export const HWP_PROP_MOBILE = 0x00001000
+export const HWP_PROP_PRIVACY = 0x00002000
+export const HWP_PROP_TRACK_CHANGES = 0x00004000
+export const HWP_PROP_KOGL = 0x00008000
+export const HWP_PROP_HAS_VIDEO = 0x00010000
+export const HWP_PROP_HAS_TOC_FIELD = 0x00020000
+
 export async function validateHwp(fileBuffer: Uint8Array): Promise<ValidateResult> {
   const result = await validateHwpBuffer(Buffer.from(fileBuffer))
   return result
@@ -70,8 +89,8 @@ export async function validateHwpBuffer(buffer: Buffer): Promise<ValidateResult>
   }
 
   const cfbLayer = validateCfbStructure(cfb)
-  checks.push(cfbLayer.check)
-  if (cfbLayer.check.status === 'fail') {
+  checks.push(...cfbLayer.checks)
+  if (cfbLayer.checks.some((check) => check.status === 'fail')) {
     return {
       valid: false,
       format: 'hwp',
@@ -116,19 +135,19 @@ export async function validateHwpBuffer(buffer: Buffer): Promise<ValidateResult>
   }
 }
 
-function validateCfbStructure(cfb: CFB.CFB$Container): { check: CheckResult; isCompressed: boolean } {
+function validateCfbStructure(cfb: CFB.CFB$Container): { checks: CheckResult[]; isCompressed: boolean } {
   const fileHeaderEntry = findEntry(cfb, '/FileHeader', 'FileHeader')
   if (!fileHeaderEntry?.content) {
     return {
-      check: { name: 'cfb_structure', status: 'fail', message: 'Missing FileHeader stream' },
+      checks: [{ name: 'cfb_structure', status: 'fail', message: 'Missing FileHeader stream' }],
       isCompressed: false,
     }
   }
 
   const headerContent = Buffer.from(fileHeaderEntry.content)
-  if (headerContent.length < 40) {
+  if (headerContent.length < 44) {
     return {
-      check: { name: 'cfb_structure', status: 'fail', message: 'Invalid FileHeader length' },
+      checks: [{ name: 'cfb_structure', status: 'fail', message: 'Invalid FileHeader length' }],
       isCompressed: false,
     }
   }
@@ -136,23 +155,104 @@ function validateCfbStructure(cfb: CFB.CFB$Container): { check: CheckResult; isC
   const signature = headerContent.subarray(0, 17).toString('ascii')
   if (!signature.startsWith('HWP Document File')) {
     return {
-      check: { name: 'cfb_structure', status: 'fail', message: 'Invalid HWP signature' },
+      checks: [{ name: 'cfb_structure', status: 'fail', message: 'Invalid HWP signature' }],
       isCompressed: false,
     }
   }
 
-  const flags = headerContent.readUInt32LE(36)
-  if (flags & 0x2) {
+  const versionRaw = headerContent.readUInt32LE(32)
+  const version = {
+    major: (versionRaw >>> 24) & 0xff,
+    minor: (versionRaw >>> 16) & 0xff,
+    micro: (versionRaw >>> 8) & 0xff,
+    build: versionRaw & 0xff,
+    raw: versionRaw,
+  }
+  const flags1 = headerContent.readUInt32LE(36)
+  const flags2 = headerContent.readUInt32LE(40)
+  const propertyDetails = {
+    properties1: flags1,
+    properties2: flags2,
+    compressed: Boolean(flags1 & HWP_PROP_COMPRESSED),
+    hasScripts: Boolean(flags1 & HWP_PROP_HAS_SCRIPTS),
+    hasDocHistory: Boolean(flags1 & HWP_PROP_HAS_DOCHISTORY),
+    hasSignature: Boolean(flags1 & HWP_PROP_HAS_SIGNATURE),
+    ccl: Boolean(flags1 & HWP_PROP_CCL),
+    kogl: Boolean(flags1 & HWP_PROP_KOGL),
+    mobileOptimized: Boolean(flags1 & HWP_PROP_MOBILE),
+    privacySecured: Boolean(flags1 & HWP_PROP_PRIVACY),
+    trackChanges: Boolean(flags1 & HWP_PROP_TRACK_CHANGES),
+    hasVideo: Boolean(flags1 & HWP_PROP_HAS_VIDEO),
+    hasTocField: Boolean(flags1 & HWP_PROP_HAS_TOC_FIELD),
+  }
+  const cfbStructureCheck: CheckResult = {
+    name: 'cfb_structure',
+    status: 'pass',
+    details: {
+      ...propertyDetails,
+      version,
+    },
+  }
+
+  if (flags1 & HWP_PROP_ENCRYPTED) {
     return {
-      check: { name: 'cfb_structure', status: 'fail', message: 'Password-protected files are not supported' },
+      checks: [{ ...cfbStructureCheck, status: 'fail', message: 'Password-protected files are not supported' }],
       isCompressed: false,
     }
+  }
+
+  if (flags1 & HWP_PROP_DISTRIBUTION) {
+    return {
+      checks: [
+        {
+          ...cfbStructureCheck,
+          status: 'fail',
+          message: 'Distribution documents are not supported (BodyText is stored in ViewText)',
+        },
+      ],
+      isCompressed: false,
+    }
+  }
+
+  if (flags1 & (HWP_PROP_DRM | HWP_PROP_CERT_DRM | HWP_PROP_CERT_ENCRYPTED)) {
+    return {
+      checks: [{ ...cfbStructureCheck, status: 'fail', message: 'DRM-protected files are not supported' }],
+      isCompressed: false,
+    }
+  }
+
+  const checks: CheckResult[] = [cfbStructureCheck]
+  if (version.raw === 0) {
+    checks.push({
+      name: 'schema_version',
+      status: 'warn',
+      message: 'FileHeader FILEVERSION is zero; cannot determine HWP schema version',
+      details: { version },
+    })
+  } else if (version.major !== 5) {
+    checks.push({
+      name: 'schema_version',
+      status: 'fail',
+      message: `Unsupported HWP schema version ${version.major}.${version.minor}.${version.micro}.${version.build}`,
+      details: { version },
+    })
+  } else {
+    checks.push({ name: 'schema_version', status: 'pass', details: { version } })
+  }
+
+  if (propertyDetails.trackChanges) {
+    checks.push({
+      name: 'document_properties',
+      status: 'warn',
+      message: 'Document has track changes enabled; editing may lose revision history',
+      details: propertyDetails,
+    })
   }
 
   const docInfoEntry = findEntry(cfb, '/DocInfo', 'DocInfo')
   if (!docInfoEntry?.content) {
     return {
-      check: { name: 'cfb_structure', status: 'fail', message: 'Missing DocInfo stream' },
+      checks: [{ ...cfbStructureCheck, status: 'fail', message: 'Missing DocInfo stream' }, ...checks.slice(1)],
       isCompressed: false,
     }
   }
@@ -160,14 +260,14 @@ function validateCfbStructure(cfb: CFB.CFB$Container): { check: CheckResult; isC
   const section0Entry = findEntry(cfb, '/BodyText/Section0', 'BodyText/Section0')
   if (!section0Entry?.content) {
     return {
-      check: { name: 'cfb_structure', status: 'fail', message: 'Missing BodyText/Section0 stream' },
+      checks: [{ ...cfbStructureCheck, status: 'fail', message: 'Missing BodyText/Section0 stream' }, ...checks.slice(1)],
       isCompressed: false,
     }
   }
 
   return {
-    check: { name: 'cfb_structure', status: 'pass' },
-    isCompressed: Boolean(flags & 0x1),
+    checks,
+    isCompressed: propertyDetails.compressed,
   }
 }
 
@@ -643,7 +743,7 @@ function validateEmptyParagraphText(sectionStreams: StreamRef[]): CheckResult {
     return {
       name: 'empty_paragraph_text',
       status: 'fail',
-      message: `${issues.length} empty paragraph(s) have PARA_TEXT records (should be omitted for nChars ≤ 1)`,
+      message: `${issues.length} empty paragraph(s) contain PARA_TEXT with only the paragraph-end marker (0x000D); non-minimal encoding, not necessarily corruption`,
       details: {
         issueCount: issues.length,
         examples: issues.slice(0, 5),


### PR DESCRIPTION
## Summary
- Decode `FileHeader.properties1`/`properties2` in the HWP validator so password, distribution, DRM, and track-changes flags are interpreted correctly instead of treating the field as a single encryption bit.
- Parse `FILEVERSION` from `FileHeader`, expose decoded version/flag details to callers, and add a dedicated `schema_version` check so validator decisions can be version-aware.
- Keep `empty_paragraph_text` as a fail-level minimality lint, but clarify the message after checking every real fixture and confirming the `0x000D`-only case does not occur in legitimate corpus files.

## Spec references
- Hancom HWP 5.0 공개 문서 download page (FileHeader structure / version / properties flags): https://www.hancom.com/etc/hwpDownload.do
- Hancom Tech overview of HWP FileHeader and properties bits: https://tech.hancom.com/%ED%95%9C-%EA%B8%80-%EB%AC%B8%EC%84%9C-%ED%8C%8C%EC%9D%BC-%ED%98%95%EC%8B%9D-hwp-%ED%8F%AC%EB%A7%B7-%EA%B5%AC%EC%A1%B0-%EC%82%B4%ED%8E%B4%EB%B3%B4%EA%B8%B0/
- pyhwp `hwp5proc header` docs showing decoded FileHeader flags and version output: https://pyhwp.readthedocs.io/en/latest/hwp5proc.html
- hwp.js reference implementation repository: https://github.com/hahnlee/hwp.js/

## Investigation results
Ran `validateHwpBuffer` against every `.hwp` fixture in `e2e/fixtures` (excluding no files; `README-corrupted.hwp` was included separately as the known-bad case).

| Fixture | `empty_paragraph_text` | Overall result |
| --- | --- | --- |
| `개정 표준근로계약서(2025년, 배포).hwp` | pass | valid |
| `개정 표준취업규칙(2025년, 배포).hwp` | pass | valid |
| `근로소득원천징수영수증(개정안 2021.11.29.).hwp` | pass | valid |
| `임금 등 청구의 소.hwp` | pass | valid |
| `표준 근로계약서(7종)(19.6월).hwp` | pass | valid |
| `폭행죄(고소장).hwp` | pass | valid |
| `피해자_의견_진술서_양식.hwp` | pass | valid |
| `README-corrupted.hwp` | pass | invalid for unrelated `content_completeness` failure |

Conclusion: the `0x000D`-only PARA_TEXT pattern did **not** appear in any legitimate fixture, and it did not explain the existing corrupted fixture failure either. I kept the check as `fail`, but changed the message to describe it as a non-minimal encoding lint rather than proof of structural corruption.

## Tests
- Added fatal flag coverage for distribution, DRM, and cert-DRM FileHeader properties bits.
- Added warning-path coverage for track-changes documents and detail-surfacing assertions for decoded FileHeader properties.
- Added `FILEVERSION` parsing coverage for `5.0.3.5` and a hard-fail test for non-5.x documents.
- Added an `empty_paragraph_text` regression test for paragraphs whose PARA_TEXT contains only `0x000D`.

## Compatibility notes
- `validateHwpBuffer` now returns a `schema_version` check and includes decoded FileHeader details on `cfb_structure`.
- Distribution and DRM-protected HWP files now fail early with explicit validator messages instead of being misclassified or slipping through.
- Documents with track changes enabled remain `valid: true`, but now surface a `document_properties` warning.
- Synthetic/test files with a zeroed `FILEVERSION` field are treated as `schema_version: warn` rather than fail so existing internal fixtures continue to validate until their headers are normalized.

## Part of
PR 1/4 in the HWP validator improvement series.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the HWP validator version-aware and decode `FileHeader` flags correctly, so password/distribution/DRM files fail fast and track-changes files surface as warnings. Also clarifies the empty paragraph lint.

- **New Features**
  - Decode `FileHeader.properties1`/`properties2` and expose details on `cfb_structure.details` (compression, scripts, doc history, signature, CCL/KOGL, video, TOC field, etc.).
  - Parse `FILEVERSION` and add a `schema_version` check: pass for 5.x, warn for 0, fail for non-5.x (includes decoded version in details).
  - Early-fail for password-protected, distribution, and DRM/cert-DRM documents with explicit messages.
  - Add a `document_properties` warn when track changes is enabled.
  - Keep `empty_paragraph_text` as fail, but reword to “non-minimal encoding” when PARA_TEXT only contains 0x000D.

- **Migration**
  - Consumers will now see a `schema_version` check and richer `cfb_structure.details` output.
  - Some files that previously passed may now fail early (distribution/DRM) or warn (track changes, zeroed version).

<sup>Written for commit d91058e653db2fe3ba8fe20d85994abf83abe86a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

