### PR TITLE
fix(hwpx): surface tables nested inside paragraph runs and subList-wrapped cells

### DIFF
--- a/src/formats/hwpx/mutator.test.ts
+++ b/src/formats/hwpx/mutator.test.ts
@@ -826,4 +826,50 @@ describe('mutateHwpxZip', () => {
     const decodedText = normalParsed[0]?.['hp:t']?.[0]?.['#text']
     expect(decodedText).toBe(userText)
   })
+
+  it('edits a cell in a real-Hancom-shaped table (run-nested + subList cell wrapper)', async () => {
+    const sectionXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+    <hp:run hp:charPrIDRef="0">
+      <hp:tbl>
+        <hp:tr>
+          <hp:tc>
+            <hp:cellSpan hp:colSpan="1" hp:rowSpan="1"/>
+            <hp:subList>
+              <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+                <hp:run hp:charPrIDRef="0"><hp:t>OriginalCell</hp:t></hp:run>
+              </hp:p>
+            </hp:subList>
+          </hp:tc>
+        </hp:tr>
+      </hp:tbl>
+    </hp:run>
+  </hp:p>
+</hs:sec>`
+
+    const filePath = tmpPath('mutator-realhancom')
+    const fixture = await createTestHwpx({ paragraphs: ['placeholder'] })
+    await Bun.write(filePath, fixture)
+
+    try {
+      const archive = await loadHwpx(filePath)
+      const zip = archive.getZip()
+      zip.file('Contents/section0.xml', sectionXml)
+
+      await mutateHwpxZip(zip, archive, [{ type: 'setTableCell', ref: 's0.t0.r0.c0', text: 'EditedCell' }])
+
+      const after = await zip.file('Contents/section0.xml')!.async('string')
+      expect(after).toContain('EditedCell')
+      expect(after).not.toContain('OriginalCell')
+      expect(after).toContain('hp:subList')
+
+      const sections = await parseSections(archive)
+      expect(sections[0].tables).toHaveLength(1)
+      expect(sections[0].tables[0].rows[0].cells[0].paragraphs[0].runs[0].text).toBe('EditedCell')
+    } finally {
+      await unlink(filePath)
+    }
+  })
 })

--- a/src/formats/hwpx/mutator.ts
+++ b/src/formats/hwpx/mutator.ts
@@ -597,9 +597,7 @@ function getSectionParagraphNode(sectionTree: XmlNode[], paragraphIndex: number)
 }
 
 function getTableCellNode(sectionTree: XmlNode[], tableIndex: number, rowIndex: number, cellIndex: number): XmlNode {
-  const sectionRoot = getSectionRootNode(sectionTree)
-  const sectionChildren = getElementChildren(sectionRoot, getElementName(sectionRoot))
-  const tables = getChildElements(sectionChildren, 'hp:tbl')
+  const tables = collectFlowChildElements(sectionTree, 'hp:tbl')
   const table = tables[tableIndex]
 
   if (!table) {
@@ -648,19 +646,42 @@ function getTextBoxParagraphNode(sectionTree: XmlNode[], textBoxIndex: number, p
 }
 
 function getTextBoxRectNodes(sectionTree: XmlNode[]): XmlNode[] {
+  return collectFlowChildElements(sectionTree, 'hp:rect')
+}
+
+/**
+ * Mutator-side mirror of `collectFlowChildren` in `section-parser.ts`. Returns
+ * `tag` element nodes from section flow in the same order the parser exposes
+ * them, so refs like `s0.tN` resolve to the same node on read and on write.
+ *
+ * Operates on the `preserveOrder: true` tree shape used by the mutator.
+ */
+function collectFlowChildElements(sectionTree: XmlNode[], tag: string): XmlNode[] {
   const sectionRoot = getSectionRootNode(sectionTree)
   const sectionChildren = getElementChildren(sectionRoot, getElementName(sectionRoot))
-  const sectionRects = getChildElements(sectionChildren, 'hp:rect')
+  const sectionDirect = getChildElements(sectionChildren, tag)
   const sectionParagraphs = getChildElements(sectionChildren, 'hp:p')
-  const inlineRects = sectionParagraphs.flatMap((paragraph) =>
-    getChildElements(getElementChildren(paragraph, 'hp:p'), 'hp:rect'),
-  )
-
-  return [...sectionRects, ...inlineRects]
+  const fromParagraphs = sectionParagraphs.flatMap((paragraph) => {
+    const paragraphChildren = getElementChildren(paragraph, 'hp:p')
+    const paragraphDirect = getChildElements(paragraphChildren, tag)
+    const runs = getChildElements(paragraphChildren, 'hp:run')
+    const runDirect = runs.flatMap((run) => getChildElements(getElementChildren(run, 'hp:run'), tag))
+    return [...paragraphDirect, ...runDirect]
+  })
+  return [...sectionDirect, ...fromParagraphs]
 }
 
 function getCellParagraphNodes(cellNode: XmlNode): XmlNode[] {
-  return getChildElements(getElementChildren(cellNode, 'hp:tc'), 'hp:p')
+  const cellChildren = getElementChildren(cellNode, 'hp:tc')
+  const direct = getChildElements(cellChildren, 'hp:p')
+  if (direct.length > 0) {
+    return direct
+  }
+  const subList = getChildElements(cellChildren, 'hp:subList')[0]
+  if (subList) {
+    return getChildElements(getElementChildren(subList, 'hp:subList'), 'hp:p')
+  }
+  return []
 }
 
 function getRunNodesFromParagraph(paragraphNode: XmlNode): XmlNode[] {

--- a/src/formats/hwpx/section-parser.test.ts
+++ b/src/formats/hwpx/section-parser.test.ts
@@ -137,6 +137,123 @@ describe('parseSection', () => {
     expect(section.images).toHaveLength(0)
   })
 
+  it('parses tables nested inside paragraph runs (real-world Hancom shape)', () => {
+    const xml = `<?xml version="1.0"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+    <hp:run hp:charPrIDRef="0">
+      <hp:tbl>
+        <hp:tr>
+          <hp:tc>
+            <hp:cellSpan hp:colSpan="1" hp:rowSpan="1"/>
+            <hp:subList>
+              <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+                <hp:run hp:charPrIDRef="0"><hp:t>Nested cell</hp:t></hp:run>
+              </hp:p>
+            </hp:subList>
+          </hp:tc>
+        </hp:tr>
+      </hp:tbl>
+    </hp:run>
+  </hp:p>
+</hs:sec>`
+
+    const section = parseSection(xml, 0)
+    expect(section.paragraphs).toHaveLength(1)
+    expect(section.tables).toHaveLength(1)
+    expect(section.tables[0].ref).toBe('s0.t0')
+    expect(section.tables[0].rows[0].cells[0].paragraphs[0].runs[0].text).toBe('Nested cell')
+  })
+
+  it('parses images nested inside paragraph runs', () => {
+    const xml = `<?xml version="1.0"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+    <hp:run hp:charPrIDRef="0">
+      <hp:pic hp:binDataIDRef="image1.png" hp:format="png" hp:width="100" hp:height="50"/>
+    </hp:run>
+  </hp:p>
+</hs:sec>`
+
+    const section = parseSection(xml, 0)
+    expect(section.images).toHaveLength(1)
+    expect(section.images[0].ref).toBe('s0.img0')
+    expect(section.images[0].binDataPath).toBe('BinData/image1.png')
+  })
+
+  it('preserves document order: section-direct then nested for the same tag', () => {
+    const xml = `<?xml version="1.0"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:tbl>
+    <hp:tr>
+      <hp:tc>
+        <hp:cellSpan hp:colSpan="1" hp:rowSpan="1"/>
+        <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+          <hp:run hp:charPrIDRef="0"><hp:t>direct</hp:t></hp:run>
+        </hp:p>
+      </hp:tc>
+    </hp:tr>
+  </hp:tbl>
+  <hp:p hp:id="1" hp:paraPrIDRef="0" hp:styleIDRef="0">
+    <hp:run hp:charPrIDRef="0">
+      <hp:tbl>
+        <hp:tr>
+          <hp:tc>
+            <hp:cellSpan hp:colSpan="1" hp:rowSpan="1"/>
+            <hp:subList>
+              <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+                <hp:run hp:charPrIDRef="0"><hp:t>nested</hp:t></hp:run>
+              </hp:p>
+            </hp:subList>
+          </hp:tc>
+        </hp:tr>
+      </hp:tbl>
+    </hp:run>
+  </hp:p>
+</hs:sec>`
+
+    const section = parseSection(xml, 0)
+    expect(section.tables).toHaveLength(2)
+    expect(section.tables[0].rows[0].cells[0].paragraphs[0].runs[0].text).toBe('direct')
+    expect(section.tables[1].rows[0].cells[0].paragraphs[0].runs[0].text).toBe('nested')
+  })
+
+  it('does not surface tables nested inside table cells as top-level tables', () => {
+    const xml = `<?xml version="1.0"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:tbl>
+    <hp:tr>
+      <hp:tc>
+        <hp:cellSpan hp:colSpan="1" hp:rowSpan="1"/>
+        <hp:subList>
+          <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+            <hp:run hp:charPrIDRef="0">
+              <hp:tbl>
+                <hp:tr>
+                  <hp:tc>
+                    <hp:cellSpan hp:colSpan="1" hp:rowSpan="1"/>
+                    <hp:p hp:id="0" hp:paraPrIDRef="0" hp:styleIDRef="0">
+                      <hp:run hp:charPrIDRef="0"><hp:t>inner</hp:t></hp:run>
+                    </hp:p>
+                  </hp:tc>
+                </hp:tr>
+              </hp:tbl>
+            </hp:run>
+          </hp:p>
+        </hp:subList>
+      </hp:tc>
+    </hp:tr>
+  </hp:tbl>
+</hs:sec>`
+
+    const section = parseSection(xml, 0)
+    expect(section.tables).toHaveLength(1)
+  })
+
   it('parses text boxes from rect inside paragraph', () => {
     const xml = `<?xml version="1.0"?>
 <hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"

--- a/src/formats/hwpx/section-parser.ts
+++ b/src/formats/hwpx/section-parser.ts
@@ -20,11 +20,9 @@ export function parseSection(xml: string, sectionIndex: number): Section {
   const sec = (parsed['hs:sec'] ?? {}) as XmlNode
 
   const rawParagraphs = asArray<XmlNode>(sec['hp:p'])
-  const rawTables = asArray<XmlNode>(sec['hp:tbl'])
-  const rawPics = asArray<XmlNode>(sec['hp:pic'])
-  const sectionRects = asArray<XmlNode>(sec['hp:rect'])
-  const inlineRects = rawParagraphs.flatMap((paragraph) => asArray<XmlNode>(paragraph['hp:rect']))
-  const rawRects = [...sectionRects, ...inlineRects]
+  const rawTables = collectFlowChildren(sec, rawParagraphs, 'hp:tbl')
+  const rawPics = collectFlowChildren(sec, rawParagraphs, 'hp:pic')
+  const rawRects = collectFlowChildren(sec, rawParagraphs, 'hp:rect')
 
   const paragraphs = rawParagraphs.map((paragraph, paragraphIndex) =>
     parseParagraph(paragraph, {
@@ -45,6 +43,28 @@ export function parseSection(xml: string, sectionIndex: number): Section {
     images,
     textBoxes,
   }
+}
+
+/**
+ * Collect element instances of `tag` that appear directly in the section flow,
+ * in document order. The flow is: section-level direct children, plus any
+ * children nested inside `hp:p` (paragraph-direct) or `hp:p > hp:run`
+ * (run-direct) wrappers. Real-world HWPX produced by Hancom typically wraps
+ * tables/images inside paragraph runs even when conceptually they are
+ * top-level objects, so a section-only collector misses them entirely.
+ *
+ * Traversal is intentionally narrow: we do not recurse into `hp:tc` (table
+ * cells), `hp:drawText` (text box bodies), or other subtrees, otherwise nested
+ * tables-in-cells would surface as top-level tables and break ref semantics.
+ */
+function collectFlowChildren(sec: XmlNode, paragraphs: XmlNode[], tag: string): XmlNode[] {
+  const sectionDirect = asArray<XmlNode>(sec[tag])
+  const fromParagraphs = paragraphs.flatMap((paragraph) => {
+    const paragraphDirect = asArray<XmlNode>(paragraph[tag])
+    const runDirect = asArray<XmlNode>(paragraph['hp:run']).flatMap((run) => asArray<XmlNode>(run[tag]))
+    return [...paragraphDirect, ...runDirect]
+  })
+  return [...sectionDirect, ...fromParagraphs]
 }
 
 export async function parseSections(archive: HwpxArchive): Promise<Section[]> {
@@ -141,7 +161,7 @@ function parseTableCell(
   cellIndex: number,
 ): TableCell {
   const span = (cell['hp:cellSpan'] ?? {}) as XmlNode
-  const rawParagraphs = asArray<XmlNode>(cell['hp:p'])
+  const rawParagraphs = getCellParagraphs(cell)
 
   const paragraphs = rawParagraphs.map((paragraph, paragraphIndex) =>
     parseParagraph(paragraph, {
@@ -159,6 +179,23 @@ function parseTableCell(
     colSpan: asNumber(span['hp:colSpan'], 1),
     rowSpan: asNumber(span['hp:rowSpan'], 1),
   }
+}
+
+/**
+ * Real-world HWPX wraps cell paragraphs in `<hp:subList>` (matching the spec
+ * for table-cell text containers), but minimal/synthetic HWPX often nests
+ * paragraphs directly under `<hp:tc>`. Accept both shapes.
+ */
+function getCellParagraphs(cell: XmlNode): XmlNode[] {
+  const direct = asArray<XmlNode>(cell['hp:p'])
+  if (direct.length > 0) {
+    return direct
+  }
+  const subList = cell['hp:subList']
+  if (subList && typeof subList === 'object') {
+    return asArray<XmlNode>((subList as XmlNode)['hp:p'])
+  }
+  return []
 }
 
 function parseImage(pic: XmlNode, sectionIndex: number, imageIndex: number): Image {

--- a/src/formats/hwpx/section-parser.ts
+++ b/src/formats/hwpx/section-parser.ts
@@ -56,6 +56,13 @@ export function parseSection(xml: string, sectionIndex: number): Section {
  * Traversal is intentionally narrow: we do not recurse into `hp:tc` (table
  * cells), `hp:drawText` (text box bodies), or other subtrees, otherwise nested
  * tables-in-cells would surface as top-level tables and break ref semantics.
+ *
+ * Ordering limitation: within a single paragraph, paragraph-direct nodes are
+ * emitted before run-direct nodes. True interleaved document order between
+ * these two would require `preserveOrder: true` on the upstream XML parser,
+ * which groups siblings by tag in the current mode. Not observed in
+ * real-world HWPX (paragraphs contain either paragraph-direct or run-direct
+ * instances of a given tag, not both); revisit if a fixture emerges.
  */
 function collectFlowChildren(sec: XmlNode, paragraphs: XmlNode[], tag: string): XmlNode[] {
   const sectionDirect = asArray<XmlNode>(sec[tag])

--- a/src/sdk/formats/hwpx/mutator.ts
+++ b/src/sdk/formats/hwpx/mutator.ts
@@ -598,9 +598,7 @@ function getSectionParagraphNode(sectionTree: XmlNode[], paragraphIndex: number)
 }
 
 function getTableCellNode(sectionTree: XmlNode[], tableIndex: number, rowIndex: number, cellIndex: number): XmlNode {
-  const sectionRoot = getSectionRootNode(sectionTree)
-  const sectionChildren = getElementChildren(sectionRoot, getElementName(sectionRoot))
-  const tables = getChildElements(sectionChildren, 'hp:tbl')
+  const tables = collectFlowChildElements(sectionTree, 'hp:tbl')
   const table = tables[tableIndex]
 
   if (!table) {
@@ -649,19 +647,42 @@ function getTextBoxParagraphNode(sectionTree: XmlNode[], textBoxIndex: number, p
 }
 
 function getTextBoxRectNodes(sectionTree: XmlNode[]): XmlNode[] {
+  return collectFlowChildElements(sectionTree, 'hp:rect')
+}
+
+/**
+ * Mutator-side mirror of `collectFlowChildren` in `section-parser.ts`. Returns
+ * `tag` element nodes from section flow in the same order the parser exposes
+ * them, so refs like `s0.tN` resolve to the same node on read and on write.
+ *
+ * Operates on the `preserveOrder: true` tree shape used by the mutator.
+ */
+function collectFlowChildElements(sectionTree: XmlNode[], tag: string): XmlNode[] {
   const sectionRoot = getSectionRootNode(sectionTree)
   const sectionChildren = getElementChildren(sectionRoot, getElementName(sectionRoot))
-  const sectionRects = getChildElements(sectionChildren, 'hp:rect')
+  const sectionDirect = getChildElements(sectionChildren, tag)
   const sectionParagraphs = getChildElements(sectionChildren, 'hp:p')
-  const inlineRects = sectionParagraphs.flatMap((paragraph) =>
-    getChildElements(getElementChildren(paragraph, 'hp:p'), 'hp:rect'),
-  )
-
-  return [...sectionRects, ...inlineRects]
+  const fromParagraphs = sectionParagraphs.flatMap((paragraph) => {
+    const paragraphChildren = getElementChildren(paragraph, 'hp:p')
+    const paragraphDirect = getChildElements(paragraphChildren, tag)
+    const runs = getChildElements(paragraphChildren, 'hp:run')
+    const runDirect = runs.flatMap((run) => getChildElements(getElementChildren(run, 'hp:run'), tag))
+    return [...paragraphDirect, ...runDirect]
+  })
+  return [...sectionDirect, ...fromParagraphs]
 }
 
 function getCellParagraphNodes(cellNode: XmlNode): XmlNode[] {
-  return getChildElements(getElementChildren(cellNode, 'hp:tc'), 'hp:p')
+  const cellChildren = getElementChildren(cellNode, 'hp:tc')
+  const direct = getChildElements(cellChildren, 'hp:p')
+  if (direct.length > 0) {
+    return direct
+  }
+  const subList = getChildElements(cellChildren, 'hp:subList')[0]
+  if (subList) {
+    return getChildElements(getElementChildren(subList, 'hp:subList'), 'hp:p')
+  }
+  return []
 }
 
 function getRunNodesFromParagraph(paragraphNode: XmlNode): XmlNode[] {

--- a/src/sdk/formats/hwpx/section-parser.ts
+++ b/src/sdk/formats/hwpx/section-parser.ts
@@ -20,11 +20,9 @@ export function parseSection(xml: string, sectionIndex: number): Section {
   const sec = (parsed['hs:sec'] ?? {}) as XmlNode
 
   const rawParagraphs = asArray<XmlNode>(sec['hp:p'])
-  const rawTables = asArray<XmlNode>(sec['hp:tbl'])
-  const rawPics = asArray<XmlNode>(sec['hp:pic'])
-  const sectionRects = asArray<XmlNode>(sec['hp:rect'])
-  const inlineRects = rawParagraphs.flatMap((paragraph) => asArray<XmlNode>(paragraph['hp:rect']))
-  const rawRects = [...sectionRects, ...inlineRects]
+  const rawTables = collectFlowChildren(sec, rawParagraphs, 'hp:tbl')
+  const rawPics = collectFlowChildren(sec, rawParagraphs, 'hp:pic')
+  const rawRects = collectFlowChildren(sec, rawParagraphs, 'hp:rect')
 
   const paragraphs = rawParagraphs.map((paragraph, paragraphIndex) =>
     parseParagraph(paragraph, {
@@ -45,6 +43,28 @@ export function parseSection(xml: string, sectionIndex: number): Section {
     images,
     textBoxes,
   }
+}
+
+/**
+ * Collect element instances of `tag` that appear directly in the section flow,
+ * in document order. The flow is: section-level direct children, plus any
+ * children nested inside `hp:p` (paragraph-direct) or `hp:p > hp:run`
+ * (run-direct) wrappers. Real-world HWPX produced by Hancom typically wraps
+ * tables/images inside paragraph runs even when conceptually they are
+ * top-level objects, so a section-only collector misses them entirely.
+ *
+ * Traversal is intentionally narrow: we do not recurse into `hp:tc` (table
+ * cells), `hp:drawText` (text box bodies), or other subtrees, otherwise nested
+ * tables-in-cells would surface as top-level tables and break ref semantics.
+ */
+function collectFlowChildren(sec: XmlNode, paragraphs: XmlNode[], tag: string): XmlNode[] {
+  const sectionDirect = asArray<XmlNode>(sec[tag])
+  const fromParagraphs = paragraphs.flatMap((paragraph) => {
+    const paragraphDirect = asArray<XmlNode>(paragraph[tag])
+    const runDirect = asArray<XmlNode>(paragraph['hp:run']).flatMap((run) => asArray<XmlNode>(run[tag]))
+    return [...paragraphDirect, ...runDirect]
+  })
+  return [...sectionDirect, ...fromParagraphs]
 }
 
 export async function parseSections(archive: HwpxArchive): Promise<Section[]> {
@@ -141,7 +161,7 @@ function parseTableCell(
   cellIndex: number,
 ): TableCell {
   const span = (cell['hp:cellSpan'] ?? {}) as XmlNode
-  const rawParagraphs = asArray<XmlNode>(cell['hp:p'])
+  const rawParagraphs = getCellParagraphs(cell)
 
   const paragraphs = rawParagraphs.map((paragraph, paragraphIndex) =>
     parseParagraph(paragraph, {
@@ -159,6 +179,23 @@ function parseTableCell(
     colSpan: asNumber(span['hp:colSpan'], 1),
     rowSpan: asNumber(span['hp:rowSpan'], 1),
   }
+}
+
+/**
+ * Real-world HWPX wraps cell paragraphs in `<hp:subList>` (matching the spec
+ * for table-cell text containers), but minimal/synthetic HWPX often nests
+ * paragraphs directly under `<hp:tc>`. Accept both shapes.
+ */
+function getCellParagraphs(cell: XmlNode): XmlNode[] {
+  const direct = asArray<XmlNode>(cell['hp:p'])
+  if (direct.length > 0) {
+    return direct
+  }
+  const subList = cell['hp:subList']
+  if (subList && typeof subList === 'object') {
+    return asArray<XmlNode>((subList as XmlNode)['hp:p'])
+  }
+  return []
 }
 
 function parseImage(pic: XmlNode, sectionIndex: number, imageIndex: number): Image {

--- a/src/sdk/formats/hwpx/section-parser.ts
+++ b/src/sdk/formats/hwpx/section-parser.ts
@@ -56,6 +56,13 @@ export function parseSection(xml: string, sectionIndex: number): Section {
  * Traversal is intentionally narrow: we do not recurse into `hp:tc` (table
  * cells), `hp:drawText` (text box bodies), or other subtrees, otherwise nested
  * tables-in-cells would surface as top-level tables and break ref semantics.
+ *
+ * Ordering limitation: within a single paragraph, paragraph-direct nodes are
+ * emitted before run-direct nodes. True interleaved document order between
+ * these two would require `preserveOrder: true` on the upstream XML parser,
+ * which groups siblings by tag in the current mode. Not observed in
+ * real-world HWPX (paragraphs contain either paragraph-direct or run-direct
+ * instances of a given tag, not both); revisit if a fixture emerges.
  */
 function collectFlowChildren(sec: XmlNode, paragraphs: XmlNode[], tag: string): XmlNode[] {
   const sectionDirect = asArray<XmlNode>(sec[tag])


### PR DESCRIPTION
## Summary

Real-world HWPX files produced by Hancom (e.g. Korean government 공모안내서 documents) wrap \`<hp:tbl>\`, \`<hp:pic>\`, and \`<hp:rect>\` inside \`<hp:p><hp:run>...</hp:run></hp:p>\` rather than placing them as direct children of \`<hs:sec>\`. Similarly, \`<hp:tc>\` cells can have their paragraphs wrapped in a \`<hp:subList>\` container per the OWPML spec. Because hwpilot's parser only walked direct children of \`<hs:sec>\`, these objects were invisible to \`table list\`, \`image list\`, \`read\`, and \`convert\` — returning empty results for tables that visually existed in the document.

## Changes

### Parser (`section-parser.ts`)
- Walk \`hs:sec\` → \`hp:p\` → \`hp:run\` to collect table/image/rect nodes in addition to direct \`hs:sec\` children.
- Accept both direct and \`<hp:subList>\`-wrapped paragraphs inside \`<hp:tc>\` cells.
- Traversal is intentionally narrow: does not recurse into \`hp:tc\` or \`hp:drawText\`, so nested-tables-in-cells or images-in-text-boxes do not surface as top-level objects and break ref semantics.

### Mutator (`mutator.ts`)
- Mirror the same traversal so \`s0.tN.rN.cN\` refs resolve to the same node on read and on write.
- Accept \`<hp:subList>\`-wrapped cell paragraphs when applying inline format and text edits.

### Tests
- 4 new unit tests in \`section-parser.test.ts\`: nested-in-run table, nested-in-run image, document order with mixed direct+nested, anti-recursion guard for nested-table-in-cell.
- 1 new mutator round-trip test in \`mutator.test.ts\`: edit a cell in a real-Hancom-shaped table (run-nested + subList wrapper), verify XML output and re-parse cross-validation.

## Context

A 144 KB Korean GPU 지원사업 공모안내서 \`.hwpx\` file went from 0 tables surfaced (pre-fix) to 34 tables and 115 markdown table rows (post-fix), with all user-visible tables (지원 대상별 GPU 자원 할당 정책, 선정절차 및 일정, 평가 항목 및 배점표, 제출 서류, 일반 숙지사항, 추진체계) correctly rendering.

For documents that contain only section-direct tables (the synthetic test fixture shape), index ordering is unchanged. For documents that contain only run-nested tables (real-world Hancom files), they were previously invisible so there is no ordering change. The ordering rule "section-direct first, then nested in document order" is documented in code.

## Testing

- \`bun test src/\` — 957/957 pass (0 fail), including the 5 new tests.
- \`bun test e2e/\` — 241/241 pass (3 pre-existing skips per KNOWN-ISSUES.md).
- \`bun run typecheck\` — clean.
- \`bun run lint\` — 9 pre-existing warnings, 0 errors.

## Review Notes

- The narrowness of the traversal (no recursion into \`hp:tc\`/\`hp:drawText\`) is intentional. Images embedded inside text-box \`<hp:subList>\` containers are not surfaced as top-level \`s0.imgN\` — per the OWPML spec they belong to their containing draw object; surfacing them at section level would break ref semantics. They remain accessible via \`BinData/image1.bmp\` etc. Separate enhancement if needed.
- The mutator mirrors the parser's exact traversal path so read and write refs are always consistent. Any future expansion of the parser walk must be mirrored in the mutator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced tables, images, and rects nested inside paragraph runs and supported `hp:subList`-wrapped table cell paragraphs in HWPX. Fixes empty lists and keeps read/write refs consistent for real Hancom-produced documents.

- **Bug Fixes**
  - Parser: walk `hs:sec` → `hp:p` → `hp:run` to collect `hp:tbl`/`hp:pic`/`hp:rect`; accept cell paragraphs direct or via `hp:subList`; no recursion into `hp:tc`/`hp:drawText`; documented that within a paragraph, paragraph‑direct nodes are emitted before run‑direct nodes due to parser limits.
  - Mutator: mirror the same traversal and cell handling so `s0.tN.rN.cN` refs resolve on edits and match reads.
  - Tests: added cases for run‑nested tables/images, ordering, anti‑recursion, and a round‑trip edit for a `hp:subList` cell.

<sup>Written for commit ebc707d965492da17ed2e960d49d31427042325c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

